### PR TITLE
Typos

### DIFF
--- a/data/classes.json
+++ b/data/classes.json
@@ -4234,7 +4234,7 @@
                      {
                         "name": "Martial Archetype: Eldritch Knight",
                         "text": [
-                           "The archetypal Eldritch Knight combines the martial mastery common to all fighters with a careful study of magic. Eldritch Knights use magical techniques similar to those practiced by wizards. They focus their study on two of the eight schools of magic - abjuration and evocation. Abjuration spells grant an Eldritch Knight additional protection in battle, and evocation spells deal damage to many foes at once, extending the fighter's reach in combat. These knights learn a comparatively small number of spells, committing them to memory instead of keeping them in a spellbook."
+                           "The archetypal Eldritch Knight combines the martial mastery common to all fighters with a careful study of magic. Eldritch Knights use magical techniques similar to those practiced by wizards. They focus their study on two of the eight schools of magic/u2014abjuration and evocation. Abjuration spells grant an Eldritch Knight additional protection in battle, and evocation spells deal damage to many foes at once, extending the fighter's reach in combat. These knights learn a comparatively small number of spells, committing them to memory instead of keeping them in a spellbook."
                         ],
                         "subclass": "Martial Archetype: Eldritch Knight",
                         "parent": "Martial Archetype",
@@ -4503,7 +4503,7 @@
                         "name": "Scout: Natural Explorer",
                         "text": [
                            "You are particularly familiar with one type of natural environment and are adept at traveling and surviving in such regions. Choose one type of favored terrain: arctic, coast, desert, forest, grassland, mountain, swamp, or the Underdark. When you make an Intelligence or Wisdom check related to your favored terrain, your proficiency bonus is doubled if you are using a skill that you're proficient in.",
-                           "While traveling for an hour or more in your favored terrain, you gain the following benefits.",
+                           "While traveling for an hour or more in your favored terrain, you gain the following benefits:",
                            null,
                            "• Difficult terrain doesn't slow your group's travel.",
                            null,
@@ -4636,7 +4636,7 @@
                      {
                         "name": "Maneuver: Parry",
                         "text": [
-                           "When another creature damages you with a melee attack, you can use your reaction and expend one superiority die to reduce the damage by the number you roll on your superiority die + your Dexterity modifier"
+                           "When another creature damages you with a melee attack, you can use your reaction and expend one superiority die to reduce the damage by the number you roll on your superiority die + your Dexterity modifier."
                         ],
                         "subclass": "Martial Archetype: Battle Master",
                         "parent": "Combat Superiority",
@@ -5834,7 +5834,7 @@
                      {
                         "name": "Monastic Tradition: Way of the Kensei (UA)",
                         "text": [
-                           "Monks of the Way of Kensei train relentlessly with their weapons, to the point that the weapon becomes like an extension of the body. A kensei sees a weapon in much the same way a painter regards a brush or a writer sees parchment, ink, and quill. A sword or bow is a tool used to express the beauty and elegance of the martial arts. That such mastery makes a kensei a peerless warrior is but a side effect of intense devotion, practice, and study."
+                           "Monks of the Way of Kensei train relentlessly with their weapons, to the point that the weapon becomes like an extension of the body. A kensei sees a weapon in much the same way a painter regards a brush or a writer sees parchment, ink, and quill. A sword or bow is a tool used to express the beauty and elegance of the martial arts. That such mastery makes a kensei a peerless warrior and is but a side effect of intense devotion, practice, and study."
                         ],
                         "subclass": "Monastic Tradition: Way of the Kensei (UA)",
                         "parent": "Monastic Tradition",
@@ -5952,7 +5952,7 @@
                      {
                        "name": "Elemental Disciplines: Fangs of the Fire Snake",
                        "text": [
-                          "When you use the Attack action on your turn, you can spend 1 ki point to cause tendrils of !lame to stretch out from your fists and feet. Your reach with your unarmed strikes increases by 10 feet for that action, as well as the rest of the turn. A hit with such an attack deals fire damage instead of bludgeoning damage, and if you spend 1 ki point when the attack hits, it also deals an extra 1d1O fire damage."
+                          "When you use the Attack action on your turn, you can spend 1 ki point to cause tendrils of flame to stretch out from your fists and feet. Your reach with your unarmed strikes increases by 10 feet for that action, as well as the rest of the turn. A hit with such an attack deals fire damage instead of bludgeoning damage, and if you spend 1 ki point when the attack hits, it also deals an extra 1d10 fire damage."
                        ],
                        "subclass": "Monastic Tradition: Way of the Four Elements",
                        "parent": "Elemental Disciplines",
@@ -6092,7 +6092,7 @@
                         "name": "Way of the Sun Soul: Radiant Sun Bolt",
                         "text": [
                            "Starting when you choose this tradition at 3rd level, you can hurl searing bolts of magical radiance.",
-                           "You gain a ranged spell attack that you can use with the Attack action. The attack has a range of 30 feet. You are proficient with it, and you add your Dexterity modifier to its attack and damage rolls. Its damage is radiant, and its damage die is a d4. This die changes as you gain monk levels — to a d6 at 5th level, a d8 at 11th level, and a d10 at 17th level.",
+                           "You gain a ranged spell attack that you can use with the Attack action. The attack has a range of 30 feet. You are proficient with it, and you add your Dexterity modifier to its attack and damage rolls. Its damage is radiant, and its damage die is a d4. This die changes as you gain monk levels/u2014to a d6 at 5th level, a d8 at 11th level, and a d10 at 17th level.",
                            "When you use the Attack action on your turn to use this special attack, you can spend 1 ki point to make two additional attacks with it as a bonus action."
                         ],
                         "subclass": "Monastic Tradition: Way of the Sun Soul",
@@ -6149,7 +6149,7 @@
                      {
                         "name": "Deflect Missiles",
                         "text": [
-                           "Starting at 3rd level, you can use your reaction to deflect or catch the missile when you are hit by a ranged weapon attack. When you do so, the damage you take from the attack is reduced by 1d 10 + your Dexterity modifier + your monk level.",
+                           "Starting at 3rd level, you can use your reaction to deflect or catch the missile when you are hit by a ranged weapon attack. When you do so, the damage you take from the attack is reduced by 1d10 + your Dexterity modifier + your monk level.",
                            "If you reduce the damage to 0, you can catch the missile if it is small enough for you to hold in one hand and you have at least one hand free. If you catch a missile in this way, you can spend 1 ki point to make a ranged attack (range 20 feet/60 feet) with the weapon or piece of ammunition you just caught, as part of the same reaction. You make this attack with proficiency, regardless of your weapon proficiencies, and the missile counts as a monk weapon for the attack."
                         ]
                      }
@@ -6256,7 +6256,7 @@
                      {
                         "name": "Way of the Kensei: One with the Blade",
                         "text": [
-                           "At 6th level, you extend your ki into the weapons you hold, granting you the following benefits.",
+                           "At 6th level, you extend your ki into the weapons you hold, granting you the following benefits:",
                            "Magic Weapons. Your attacks with your kensei weapons count as magical for the purpose of overcoming resistance and immunity to nonmagical attacks and damage.",
                            "Precise Strike. You can focus your attention on a single target in battle to understand and overcome its defenses. As a bonus action, pick one creature you can see within 30 feet of you. The next weapon attack you make against that creature during the current turn adds double your proficiency bonus to the attack roll, rather than your normal proficiency bonus. Once you use this ability, you can’t use it again until you finish a short or long rest."
                         ],
@@ -6320,7 +6320,7 @@
                      {
                         "name": "Unarmored Movement improvement",
                         "text": [
-                           "You gain the ability to move along vertical surfaces and across liquids on your turn without falling during the move."
+                           "At 9th level, you gain the ability to move along vertical surfaces and across liquids on your turn without falling during the move."
                         ]
                      }
                   ],
@@ -6357,7 +6357,7 @@
                      {
                         "name": "Way of the Open Palm: Tranquility",
                         "text": [
-                           "Beginning at 11th level, you can enter a special meditation that surrounds you with an aura of peace. At the end of a long rest, you gain the effect of a sanctuary spell that lasts until the start of your next long rest (the spell can end early as normal). The saving throw DC for the spell equals 8 + your Wisdom modifier + your Proficiency bonus.",
+                           "Beginning at 11th level, you can enter a special meditation that surrounds you with an aura of peace. At the end of a long rest, you gain the effect of a sanctuary spell that lasts until the start of your next long rest (the spell can end early as normal). The saving throw DC for the spell equals 8 + your Wisdom modifier + your proficiency bonus.",
                            null,
                            "Sanctuary gives this effect: You ward a creature within range against attack. Until the spell ends, any creature who targets the warded creature with an attack or a harmful spell must first make a Wisdom saving throw. On a failed save, the creature must choose a new target or lose the attack or spell. This spell doesn't protect the warded creature from area effects, such as the explosion of a fireball.",
                            null,
@@ -10111,7 +10111,7 @@
                            "When you reach 3rd level, you gain the ability to cast spells. See chapter 10 for the general rules of spellcasting and chapter 11 for the wizard spell list.",
                            null,
                            "Cantrips",
-                           "At 1st level, You learn three cantrips: mage hand and two other cantrips of your choice from the wizard spell list. You learn another wizard cantrip of your choice at 10th level.",
+                           "At 1st level, you learn three cantrips: mage hand and two other cantrips of your choice from the wizard spell list. You learn another wizard cantrip of your choice at 10th level.",
                            null,
                            "Spell Slots",
                            "The Arcane Trickster Spellcasting table shows how many spell slots you have to cast your spells of 1st level and higher. To cast one of these spells, you must expend a slot of the spell's level or higher. You regain all expended spell slots when you finish a long rest.",


### PR DESCRIPTION
Spellchecked the following non-spellcaster classes: Fighter, Monk, and Rogue.