### PR TITLE
Fixed various HTML tag issues

### DIFF
--- a/bestiary.html
+++ b/bestiary.html
@@ -120,7 +120,7 @@
 						<th class="border" colspan="6"></th>
 					</tr>
 					<tr>
-						<th id="name" colspan="6">Name <span class="source" title="Source book">SRC</source></th>
+						<th id="name" colspan="6">Name <span class="source" title="Source book">SRC</span></th>
 							</tr>
 							<tr>
 								<td id="sizetypealignment" colspan="6"><span id="size">Size</span> <span id="type">type</span>, <span id="alignment">alignment</span></td>

--- a/classes.html
+++ b/classes.html
@@ -445,7 +445,7 @@
 					</tr>
 					<tr>
 						<td id="hp" colspan="6">
-							<h5>Hit Points</h3>
+							<h5>Hit Points</h5>
 								<div id="hitdice">
 									<strong>Hit Dice:</strong>
 									<span> </span>

--- a/crcalculator.html
+++ b/crcalculator.html
@@ -174,8 +174,8 @@
 								A monster's HP is multiplied based on the resistances and immunities has to common damage types (non-magical budgeoning, piercing, and slashing chief among them).
 							</span></label>
 					<span class="inputwrap">
-								<select id="resistances" value="0">
-									<option value="0">None</option>
+								<select id="resistances">
+									<option value="0" selected>None</option>
 									<option value="res">Resistances</option>
 									<option value="imm">Immunities</option>
 								</select>
@@ -192,8 +192,8 @@
 										Increase a creature's effective AC by 2 if it has 3 or 4 saving throw proficiencies, or by 4 if it has 5 or 6.
 									</span></label>
 					<span class="inputwrap">
-										<select id="saveprofs" value="0">
-											<option value="0">0-2</option>
+										<select id="saveprofs">
+											<option value="0" selected>0-2</option>
 											<option value="2">3-4</option>
 											<option value="4">5-6</option>
 										</select>

--- a/items.html
+++ b/items.html
@@ -86,7 +86,7 @@
 					<select class="sourcefilter">
 							<option value="All">All Sources</option>
 						</select>
-					<select class="typefilter" value="All">
+					<select class="typefilter">
 							<option value="All">All Types</option>
 						</select>
 					</select>

--- a/lootgen.html
+++ b/lootgen.html
@@ -79,8 +79,8 @@
 				<form id="controls">
 					<div class="input-group">
 						<span class="input-group-addon">CR</span>
-						<select class="form-control" id="cr" value="0">
-							<option value="0">CR 0-4</option>
+						<select class="form-control" id="cr">
+							<option value="0" selected>CR 0-4</option>
 							<option value="5">CR 5-10</option>
 							<option value="11">CR 11-16</option>
 							<option value="17">CR 17+</option>

--- a/psionics.html
+++ b/psionics.html
@@ -61,7 +61,6 @@
 				<li role="presentation"><a href="editor.html">WYSIWYG Editor</a></li>
 			</ul>
 		</li>
-		</li>
 	</ul>
 </nav>
 <main class="container bodyContent">

--- a/spells.html
+++ b/spells.html
@@ -70,7 +70,6 @@
 					<li role="presentation"><a href="editor.html">WYSIWYG Editor</a></li>
 				</ul>
 			</li>
-			</li>
 		</ul>
 	</nav>
 	<main class="container bodyContent">

--- a/statgen.html
+++ b/statgen.html
@@ -101,7 +101,7 @@
 				<label>Budget: <input id="budget" type="number" min="10" value="27"></label>
 				<label>Remaining: <input id="remaining" type="number" min="10" value="27" readonly></label>
 				<table>
-					<th><td>Base</td><td>Racial</td><td>Total</td><td>Mod</td><td class="choose"></td></th>
+					<tr><td></td><td>Base</td><td>Racial</td><td>Total</td><td>Mod</td><td class="choose"></td></tr>
 					<tr id="str">
 						<td>STR</td>
 						<td><input type="number" min="8" max="15" value="8" data-prev="8" class="base"></td>


### PR DESCRIPTION
I used the W3C HTML Markup Validator on the latest versions of the files as I'd previously seen a few tags that didn't match-up, e.g. <span> ... </source>. Also, I replaced a few "value" entries in select tags (which I've seen not work "properly" is some older browsers) and put in the selected keyword in the associated option tag. The table header tags didn't make sense to me (and were also flagged-up by the validator), so tidied them up with using the normal table data tags (I did first use th tags but they were then rendered in bold so I kept the same appearance by using td's).