### PR TITLE
Various JSON data fixes

### DIFF
--- a/data/bestiary-tob.json
+++ b/data/bestiary-tob.json
@@ -553,9 +553,9 @@ monsterdata.compendium.monster.push(
 			"text": [
 				" The grovekeeper is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). It has the following druid spells prepared:",
 				"Cantrips (at will): druidcraft, guidance, produce flame, shillelagh",
-				"1st (4 slots): animal friendship, cure wounds, faerie fire",
-				"2nd (3 slots): animal messenger, heat metal, lesser restoration",
-				"3rd (2 slots): call lightning, dispel magic"
+				"1st level (4 slots): animal friendship, cure wounds, faerie fire",
+				"2nd level (3 slots): animal messenger, heat metal, lesser restoration",
+				"3rd level (2 slots): call lightning, dispel magic"
 			]
 		}
 	],
@@ -3126,12 +3126,12 @@ monsterdata.compendium.monster.push(
 	"ac": "17 (natural armor)",
 	"hp": "152 (16d10 + 64)",
 	"speed": "30 ft.",
-	"str": "14(+2) 20",
-	"dex": "19",
-	"con": "9",
-	"int": "13",
-	"wis": "6",
-	"cha": "",
+	"str": "14",
+	"dex": "20",
+	"con": "19",
+	"int": "9",
+	"wis": "13",
+	"cha": "6",
 	"immune": "poison; bludgeoning, piercing, and slashing from nonmagical weapons",
 	"conditionImmune": "exhaustion, paralyzed, petrified, poisoned, unconscious",
 	"senses": "darkvision 60 ft.",
@@ -7806,7 +7806,7 @@ monsterdata.compendium.monster.push(
 		{
 			"name": "Multiattack",
 			"text": [
-				"The dragon makes three attacks; one with its bite and two with its claws."
+				"The dragon makes three attacks: one with its bite and two with its claws."
 			]
 		},
 		{
@@ -9928,11 +9928,11 @@ monsterdata.compendium.monster.push(
 	"hp": "127 (15d8 + 60)",
 	"speed": "30 ft., swim 60 ft.",
 	"str": "19",
-	"dex": "17(+3)  18",
-	"con": "10",
-	"int": "13",
-	"wis": "10",
-	"cha": "",
+	"dex": "17",
+	"con": "18",
+	"int": "10",
+	"wis": "13",
+	"cha": "10",
 	"save": "Dex +6",
 	"skill": [
 		"Acrobatics +6, Perception +4, Stealth +6"
@@ -12299,7 +12299,7 @@ monsterdata.compendium.monster.push(
 	"speed": "30 ft.",
 	"str": "14",
 	"dex": "16",
-	"con": "12(+1)  14",
+	"con": "12",
 	"int": "12",
 	"wis": "18",
 	"cha": "",
@@ -15911,7 +15911,7 @@ monsterdata.compendium.monster.push(
 			"name": "Innate Spellcasting",
 			"text": [
 				"The hag's innate spellcasting ability is Charisma (spell save DC 15). She can innately cast the following spells, requiring no material components:",
-				"At will:  disguise self, knock, minor illusion, misty step, pass without trace, protection from evil and good, tongues, water breathing",
+				"At will: disguise self, knock, minor illusion, misty step, pass without trace, protection from evil and good, tongues, water breathing",
 				"3/day each: bestow curse, invisibility, mirror image",
 				"1/day each: cloudkill, modify memory"
 			]
@@ -27941,10 +27941,10 @@ monsterdata.compendium.monster.push(
 	"speed": "30 ft., swim 20 ft.",
 	"str": "16",
 	"dex": "10",
-	"con": "17(+3)  8",
-	"int": "16",
-	"wis": "8",
-	"cha": "",
+	"con": "17",
+	"int": "8",
+	"wis": "16",
+	"cha": "8",
 	"resist": "cold, fire",
 	"conditionImmune": "paralyzed, unconscious",
 	"senses": "darkvision 60 ft.",

--- a/data/bestiary.json
+++ b/data/bestiary.json
@@ -1755,7 +1755,7 @@ var monsterdata = {
 							"The alhoon magically emits psychic energy in a 60-foot cone. Each creature in that area must succeed on a DC 16 Intelligence saving throw or take 22 (4d8+4) psychic damage and be stunned for 1 minute. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 						],
 						"attack": [
-							"Mind Blast| |4d8+4"
+							"Mind Blast||4d8+4"
 						]
 					}
 				],
@@ -3277,7 +3277,7 @@ var monsterdata = {
 						],
 						"attack": [
 							"Crushing Hug|8|9d6+5",
-							"Per Turn| |9d6+5"
+							"Per Turn||9d6+5"
 						]
 					}
 				],
@@ -3838,7 +3838,7 @@ var monsterdata = {
 				"type": "undead, monster manual",
 				"alignment": "neutral evil",
 				"ac": "20",
-				"hp": "0",
+				"hp": "half the hit point maximum of its summoner",
 				"speed": "60 ft., fly 60 ft. (hover)",
 				"str": "16",
 				"dex": "16",
@@ -9503,7 +9503,7 @@ var monsterdata = {
 				],
 				"senses": "darkvision 60 ft.",
 				"passive": "14",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "1",
 				"trait": [
 					{
@@ -14326,7 +14326,7 @@ var monsterdata = {
 							"The elder brain magically emits psychic energy. Creatures of the elder brain's choice within 60 feet of it must succeed on a DC 18 Intelligence saving throw or take 32 (5d10+5) psychic damage and be stunned for 1 minute. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 						],
 						"attack": [
-							"Mind Blast| |5d10+5"
+							"Mind Blast||5d10+5"
 						]
 					},
 					{
@@ -16216,8 +16216,8 @@ var monsterdata = {
 							"The giant moves up to 30 feet in a straight line and can move through the space of any creature smaller than Huge. The first time it enters a creature's space during this move, it makes a fireshield attack against that creature. If the attack hits, the target must also succeed on a DC 21 Strength saving throw or be pushed ahead of the giant for the rest of this move. If a creature fails the save by 5 or more, it is also knocked prone and takes 18 (3d6+8) bludgeoning damage, or 29 (6d6+8) bludgeoning damage if it was already prone."
 						],
 						"attack": [
-							"Failed Save| |3d6+8",
-							"Prone Failed Save| |6d6+8"
+							"Failed Save||3d6+8",
+							"Prone Failed Save||6d6+8"
 						]
 					}
 				],
@@ -17167,7 +17167,7 @@ var monsterdata = {
 						],
 						"attack": [
 							"Bite|10|3d10+6",
-							"Acid| |3d6"
+							"Acid||3d6"
 						]
 					},
 					{
@@ -23434,7 +23434,7 @@ var monsterdata = {
 				],
 				"senses": "blindsight 30 ft.",
 				"passive": "10",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "5",
 				"trait": [
 					{
@@ -24097,7 +24097,7 @@ var monsterdata = {
 							"The illithilich magically emits psychic energy in a 60-foot cone. Each creature in that area must succeed on a DC 18 Intelligence saving throw or take 27 (5d8+5) psychic damage and be stunned for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 						],
 						"attack": [
-							"Mind Blast| |5d8+5"
+							"Mind Blast||5d8+5"
 						]
 					}
 				],
@@ -28038,7 +28038,7 @@ var monsterdata = {
 							"The thief deals an extra 14 (4d6) damage when it hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 feet of an ally of the thief that isn't incapacitated and the thief doesn't have disadvantage on the attack roll."
 						],
 						"attack": [
-							"Sneak Attack| |4d6"
+							"Sneak Attack||4d6"
 						]
 					}
 				],
@@ -28846,7 +28846,7 @@ var monsterdata = {
 							"If the target is an object weighing 300 pounds or less that isn't being worn or carried, it is telekinetically moved up to 30 feet in any direction. The mindwitness can also exert fine control on objects with this ray, such as manipulating a simple tool or opening a door or a container."
 						],
 						"attack": [
-							"Psychic Ray| |6d8"
+							"Psychic Ray||6d8"
 						]
 					}
 				],
@@ -29322,7 +29322,7 @@ var monsterdata = {
 						],
 						"attack": [
 							"Tentacles|13|3d8+8+3d8",
-							"Acid Damage| |10d6"
+							"Acid Damage||10d6"
 						]
 					},
 					{
@@ -29331,7 +29331,7 @@ var monsterdata = {
 							"The neothelid exhales acid in a 60-foot cone. Each creature in that area must make a DC 18 Dexterity saving throw, taking 35 (10d6) acid damage on a failed save, or half as much damage on a successful one."
 						],
 						"attack": [
-							"Acid Breath | |10d6"
+							"Acid Breath ||10d6"
 						]
 					}
 				],
@@ -29412,7 +29412,7 @@ var monsterdata = {
 						"In response to another creature dealing damage to the nilbog, the nilbog reduces the damage to 0 and regains 1d6 hit points."
 					],
 					"attack": [
-						"Reversal of Fortune| |1d6"
+						"Reversal of Fortune||1d6"
 					]
 				},
 				"spells": "mage hand, Tasha's hideous laughter, vicious mockery, confusion"
@@ -29659,7 +29659,7 @@ var monsterdata = {
 							"When the orc is reduced to 0 hit points, it explodes, and any creature within 10 feet of it must make a DC 13 Constitution saving throw. On a failed save, the creature takes 14 (4d6) poison damage and becomes poisoned. On a success, the creature takes half as much damage and isn‘t poisoned. A creature poisoned by this effect can repeat the save at the end of each of its turn, ending the effect on itself on a success. While poisoned by this effect, a creature can't regain hit points."
 						],
 						"attack": [
-							"Explosion| |4d6"
+							"Explosion||4d6"
 						]
 					},
 					{
@@ -30058,7 +30058,7 @@ var monsterdata = {
 							"The redcap moves up to its speed to a creature it can see and kicks with its iron boots. The target must succeed on a DC 14 Dexterity saving throw or take 20 (3d10+4) bludgeoning damage and be knocked prone."
 						],
 						"attack": [
-							"Kick| |3d10+4"
+							"Kick||3d10+4"
 						]
 					}
 				],
@@ -40951,7 +40951,7 @@ var monsterdata = {
 							"One Large or smaller creature within 5 feet of the trapper must succeed on a DC 14 Dexterity saving throw or be grappled (escape DC 14). Until the grapple ends, the target takes 17 (4d6+3) bludgeoning damage plus 3 (1d6) acid damage at the start of each of its turns. While grappled in this way, the target is restrained, blinded, and at risk of suffocating. The trapper can smother only one creature at a time."
 						],
 						"attack": [
-							"Smother| |4d6+3+1d6"
+							"Smother||4d6+3+1d6"
 						]
 					}
 				],
@@ -41704,7 +41704,7 @@ var monsterdata = {
 							"The ulitharid magically emits psychic energy in a 60-foot cone. Each creature in that area must succeed on a DC 17 Intelligence saving throw or take 31 (4d12+5) psychic damage and be stunned for 1 minute. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 						],
 						"attack": [
-							"Mind Blast| |4d12+5"
+							"Mind Blast||4d12+5"
 						]
 					}
 				],
@@ -42805,7 +42805,7 @@ var monsterdata = {
 							"A 15-foot-radius cloud of toxic spores extends out from the vegepygmy. The spores spread around corners. Each creature in that area that isn't a plant must succeed on a DC 12 Constitution saving throw or be poisoned. While poisoned in this way, a target takes 9 (2d8) poison damage at the start of each of its turns. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 						],
 						"attack": [
-							"Spores| |2d8"
+							"Spores||2d8"
 						]
 					}
 				],
@@ -46766,7 +46766,7 @@ var monsterdata = {
 					{
 						"name": "Innate Spellcasting (Abomination Form Only)",
 						"text": [
-							"The yuan_ti's innate spellcasting ability is Charisma (spell save DC 15). The yuan_ti can innately cast the following spells, requiring no material components:",
+							"The yuan-ti's innate spellcasting ability is Charisma (spell save DC 15). The yuan-ti can innately cast the following spells, requiring no material components:",
 							"At will: animal friendship (snakes only)",
 							"3/day: suggestion",
 							"1/day: fear"
@@ -46783,7 +46783,7 @@ var monsterdata = {
 					{
 						"name": "Multiattack (Abomination Form Only)",
 						"text": [
-							"The yuan_ti makes two ranged attacks or three melee attacks, but can use its bite and constrict attacks only once each."
+							"The yuan-ti makes two ranged attacks or three melee attacks, but can use its bite and constrict attacks only once each."
 						]
 					},
 					{
@@ -46798,7 +46798,7 @@ var monsterdata = {
 					{
 						"name": "Constrict",
 						"text": [
-							"Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage, and the target is grappled (escape DC 14). Until this grapple ends, the target is restrained, and the yuan_ti can't constrict another target."
+							"Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage, and the target is grappled (escape DC 14). Until this grapple ends, the target is restrained, and the yuan-ti can't constrict another target."
 						],
 						"attack": [
 							"|7|2d6+4"
@@ -47052,9 +47052,9 @@ var monsterdata = {
 						]
 					},
 					{
-						"name": "Innate Spellcasting (Yuan_ti Form Only)",
+						"name": "Innate Spellcasting (yuan-ti Form Only)",
 						"text": [
-							"The yuan_ti's innate spellcasting ability is Charisma (spell save DC 13). The yuan_ti can innately cast the following spells, requiring no material components:",
+							"The yuan-ti's innate spellcasting ability is Charisma (spell save DC 13). The yuan-ti can innately cast the following spells, requiring no material components:",
 							"At will: animal friendship (snakes only)",
 							"3/day: suggestion"
 						]
@@ -47068,7 +47068,7 @@ var monsterdata = {
 					{
 						"name": "Malison Type",
 						"text": [
-							"The yuan_ti has one of the following types:",
+							"The yuan-ti has one of the following types:",
 							"Type 1: Human body with snake head",
 							"Type 2: Human head and body with snakes for arms",
 							"Type 3: Human head and upper body with a serpentine lower body instead of legs"
@@ -47077,9 +47077,9 @@ var monsterdata = {
 				],
 				"action": [
 					{
-						"name": "Multiattack (Yuan_ti Form Only)",
+						"name": "Multiattack (yuan-ti Form Only)",
 						"text": [
-							"The yuan_ti makes two ranged attacks or two melee attacks, but can use its bite only once."
+							"The yuan-ti makes two ranged attacks or two melee attacks, but can use its bite only once."
 						]
 					},
 					{
@@ -47092,7 +47092,7 @@ var monsterdata = {
 						]
 					},
 					{
-						"name": "Scimitar (Yuan_ti Form Only)",
+						"name": "Scimitar (yuan-ti Form Only)",
 						"text": [
 							"Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage."
 						],
@@ -47101,7 +47101,7 @@ var monsterdata = {
 						]
 					},
 					{
-						"name": "Longbow (Yuan_ti Form Only)",
+						"name": "Longbow (yuan-ti Form Only)",
 						"text": [
 							"Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage plus 7 (2d6) poison damage."
 						],
@@ -47143,9 +47143,9 @@ var monsterdata = {
 						]
 					},
 					{
-						"name": "Innate Spellcasting (Yuan_ti Form Only)",
+						"name": "Innate Spellcasting (yuan-ti Form Only)",
 						"text": [
-							"The yuan_ti's innate spellcasting ability is Charisma (spell save DC 13). The yuan_ti can innately cast the following spells, requiring no material components:",
+							"The yuan-ti's innate spellcasting ability is Charisma (spell save DC 13). The yuan-ti can innately cast the following spells, requiring no material components:",
 							"At will: animal friendship (snakes only)",
 							"3/day: suggestion"
 						]
@@ -47159,7 +47159,7 @@ var monsterdata = {
 					{
 						"name": "Malison Type",
 						"text": [
-							"The yuan_ti has one of the following types:",
+							"The yuan-ti has one of the following types:",
 							"Type 1: Human body with snake head",
 							"Type 2: Human head and body with snakes for arms",
 							"Type 3: Human head and upper body with a serpentine lower body instead of legs"
@@ -47168,9 +47168,9 @@ var monsterdata = {
 				],
 				"action": [
 					{
-						"name": "Multiattack (Yuan_ti Form Only)",
+						"name": "Multiattack (yuan-ti Form Only)",
 						"text": [
-							"The yuan_ti makes two bite attacks using its snake arms."
+							"The yuan-ti makes two bite attacks using its snake arms."
 						]
 					},
 					{
@@ -47216,9 +47216,9 @@ var monsterdata = {
 						]
 					},
 					{
-						"name": "Innate Spellcasting (Yuan_ti Form Only)",
+						"name": "Innate Spellcasting (yuan-ti Form Only)",
 						"text": [
-							"The yuan_ti's innate spellcasting ability is Charisma (spell save DC 13). The yuan_ti can innately cast the following spells, requiring no material components:",
+							"The yuan-ti's innate spellcasting ability is Charisma (spell save DC 13). The yuan-ti can innately cast the following spells, requiring no material components:",
 							"At will: animal friendship (snakes only)",
 							"3/day: suggestion"
 						]
@@ -47232,7 +47232,7 @@ var monsterdata = {
 					{
 						"name": "Malison Type",
 						"text": [
-							"The yuan_ti has one of the following types:",
+							"The yuan-ti has one of the following types:",
 							"Type 1: Human body with snake head",
 							"Type 2: Human head and body with snakes for arms",
 							"Type 3: Human head and upper body with a serpentine lower body instead of legs"
@@ -47241,9 +47241,9 @@ var monsterdata = {
 				],
 				"action": [
 					{
-						"name": "Multiattack (Yuan_ti Form Only)",
+						"name": "Multiattack (yuan-ti Form Only)",
 						"text": [
-							"The yuan_ti makes two ranged attacks or two melee attacks, but can constrict only once."
+							"The yuan-ti makes two ranged attacks or two melee attacks, but can constrict only once."
 						]
 					},
 					{
@@ -47258,14 +47258,14 @@ var monsterdata = {
 					{
 						"name": "Constrict",
 						"text": [
-							"Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) bludgeoning damage, and the target is grappled (escape DC 13). Until this grapple ends, the target is restrained, and the yuan_ti can't constrict another target."
+							"Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) bludgeoning damage, and the target is grappled (escape DC 13). Until this grapple ends, the target is restrained, and the yuan-ti can't constrict another target."
 						],
 						"attack": [
 							"|5|2d6+3"
 						]
 					},
 					{
-						"name": "Scimitar (Yuan_ti Form Only)",
+						"name": "Scimitar (yuan-ti Form Only)",
 						"text": [
 							"Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage."
 						],
@@ -47274,7 +47274,7 @@ var monsterdata = {
 						]
 					},
 					{
-						"name": "Longbow (Yuan_ti Form Only)",
+						"name": "Longbow (yuan-ti Form Only)",
 						"text": [
 							"Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage."
 						],
@@ -47338,7 +47338,7 @@ var monsterdata = {
 							"The first time the yuan-ti hits with a melee attack on its turn, it can deal an extra 16 (3d10) psychic damage to the target."
 						],
 						"attack": [
-							"Mind Fangs| |3d10"
+							"Mind Fangs||3d10"
 						]
 					},
 					{
@@ -47435,7 +47435,7 @@ var monsterdata = {
 							"The first time the yuan-ti hits with a melee attack on its turn, it can deal an extra 16 (3d10) necrotic damage to the target."
 						],
 						"attack": [
-							"Death Fangs| |3d10"
+							"Death Fangs||3d10"
 						]
 					},
 					{
@@ -47504,7 +47504,7 @@ var monsterdata = {
 							"The yuan-ti taps into the nightmares of a creature it can see within 60 feet of it and creates an illusory, immobile manifestation of the creature's deepest fears, visible only to that creature. The target must make a DC 13 Intelligence saving throw. On a failed save, the target takes 11 (2d10) psychic damage and is frightened of the manifestation, believing it to be real. The yuan-ti must concentrate to maintain the illusion (as if concentrating on a spell), which lasts for up to 1 minute and can't be harmed. The target can repeat the saving throw at the end of each of its turns, ending the illusion on a success, or taking 11 (2d10) psychic damage on a failure."
 						],
 						"attack": [
-							"Nightmare| |2d10"
+							"Nightmare||2d10"
 						]
 					}
 				],
@@ -47563,7 +47563,7 @@ var monsterdata = {
 							"The first time the yuan-ti hits with a melee attack on its turn, it can deal an extra 16 (3d10) poison damage to the target."
 						],
 						"attack": [
-							"Poison's Disciple| |3d10"
+							"Poison's Disciple||3d10"
 						]
 					},
 					{
@@ -48995,7 +48995,7 @@ var monsterdata = {
 				"wis": "14",
 				"cha": "16",
 				"skill": [
-					"Acrobatic +5, Nature +3, Stealth +5, Survival +4"
+					"Acrobatics +5, Nature +3, Stealth +5, Survival +4"
 				],
 				"senses": "darkvision 60 ft.",
 				"passive": "12",
@@ -49382,8 +49382,8 @@ var monsterdata = {
 				"source": "Tales from the Yawning Portal",
 				"name": "Snarla",
 				"size": "M",
-				"type": "humanoid (human",
-				"alignment": "shapechanger)",
+				"type": "humanoid (human, shapechanger)",
+				"alignment": "",
 				"ac": "11 (in humanoid form, 12 in wolf or hybrid form)",
 				"hp": "58 (9d8+18)",
 				"speed": "30 ft. (40 ft. in wolf form)",
@@ -50497,7 +50497,7 @@ var monsterdata = {
 				],
 				"senses": "darkvision 60 ft.",
 				"passive": "14",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "5",
 				"trait": [],
 				"action": [
@@ -50765,12 +50765,12 @@ var monsterdata = {
 				"ac": "11",
 				"hp": "45 (10d8)",
 				"speed": "0 ft., fly 40 ft.",
-				"str": "7 (−2) 13",
-				"dex": "10",
+				"str": "7",
+				"dex": "13",
 				"con": "10",
-				"int": "12",
-				"wis": "17",
-				"cha": "",
+				"int": "10",
+				"wis": "12",
+				"cha": "17",
 				"resist": "acid, fire, lightning, thunder; bludgeoning,",
 				"immune": "cold, necrotic, poison",
 				"conditionImmune": "charmed, exhaustion, frightened, grappled,",
@@ -51667,7 +51667,7 @@ var monsterdata = {
 				"skill": ["Perception +4, Stealth +5"],
 				"senses": "darkvision 30 ft.",
 				"passive": "14",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "0",
 				"trait": [
 					{
@@ -51705,7 +51705,7 @@ var monsterdata = {
 				"conditionImmune": "poisoned",
 				"senses": "darkvision 60 ft.",
 				"passive": "8",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "3",
 				"trait": [
 					{
@@ -51807,7 +51807,7 @@ var monsterdata = {
 				"conditionImmune": "blinded, deafened, exhaustion, prone",
 				"senses": "blindsight 30 ft.",
 				"passive": "10",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "3",
 				"trait": [
 					{
@@ -51939,7 +51939,7 @@ var monsterdata = {
 				"size": "T",
 				"type": "elemental",
 				"alignment": "neutral",
-				"ac": "155",
+				"ac": "15",
 				"hp": "5 (2d4)",
 				"speed": "20 ft., climb 20 ft., swim 20 ft.",
 				"str": "1",
@@ -51950,7 +51950,7 @@ var monsterdata = {
 				"cha": "16",
 				"skill": ["Acrobatics +7, Perception +7, Stealth +7"],
 				"senses": "Senses blindsight 60 h., passive Perception 17",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "0",
 				"trait": [
 					{
@@ -52097,7 +52097,7 @@ var monsterdata = {
 				"wis": "12",
 				"cha": "6",
 				"passive": "11",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "0",
 				"trait": [
 					{
@@ -52184,7 +52184,7 @@ var monsterdata = {
 				"int": "2",
 				"wis": "12",
 				"cha": "5",
-				"languages": "\u2014",
+				"languages": "",
 				"senses": "darvision 60 ft.",
 				"passive": "11",
 				"cr": "3",
@@ -52229,7 +52229,7 @@ var monsterdata = {
 				"immune": "poison",
 				"conditionImmune": "poisoned",
 				"senses": "darkvision 60 ft., passivePerception 8",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "3",
 				"trait": [
 					{
@@ -52284,7 +52284,7 @@ var monsterdata = {
 				"skill": ["Athletics +4, Perception +1, Stealth +4"],
 				"senses": "blindsight 30 ft.",
 				"passive": "11",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "1/2",
 				"trait": [
 					{
@@ -52332,7 +52332,7 @@ var monsterdata = {
 				"cha": "10",
 				"skill": ["Perception +4, Stealth +7"],
 				"passive": "14",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "4",
 				"trait": [
 					{
@@ -52455,7 +52455,7 @@ var monsterdata = {
 				"conditionImmune": "blinded, deafened, exhaustion, prone",
 				"senses": "tremorsense 30 ft.",
 				"passive": "10",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "1",
 				"trait": [
 					{
@@ -52683,7 +52683,7 @@ var monsterdata = {
 				"conditionImmune": "blinded, charmed, deafened, exhaustion, frightened , paralyzed, petrified, poisoned, prone",
 				"senses": "blindsight 120 ft.",
 				"passive": "10",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "12",
 				"trait": [
 					{
@@ -52893,7 +52893,7 @@ var monsterdata = {
 				"conditionImmune": "blinded, deafened, exhaustion, prone",
 				"senses": "blindsight 30 ft.",
 				"passive": "10",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "1/2",
 				"action": [
 					{
@@ -52935,7 +52935,7 @@ var monsterdata = {
 				"conditionImmune": "poisoned",
 				"senses": "darkvision 60 ft.",
 				"passive": "6",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "8",
 				"trait": [
 					{
@@ -53079,7 +53079,7 @@ var monsterdata = {
 				"conditionImmune": "blinded, deafened, exhaustion, prone",
 				"senses": "blindsight 30 ft.",
 				"passive": "10",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "2",
 				"trait": [
 					{
@@ -53128,7 +53128,7 @@ var monsterdata = {
 				"conditionImmune": "charmed, exhaustion",
 				"senses": "blindsight 30 ft.",
 				"passive": "8",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "1/4",
 				"trait": [
 					{
@@ -53235,7 +53235,7 @@ var monsterdata = {
 				"cha": "7",
 				"skill": ["Athletics +3"],
 				"passive": "11",
-				"languages": "\u2014",
+				"languages": "",
 				"cr": "1/2",
 				"trait": [
 					{

--- a/data/feats.json
+++ b/data/feats.json
@@ -3,6 +3,38 @@ var featdata =
 	"compendium": {
 		"feat": [
 			{
+				"name": "Fell Handed",
+				"source": "UAFT",
+				"text": [
+					"You master the handaxe, battleaxe, greataxe, warhammer, and maul. You gain the following benefits when using any of them:",
+					{
+						"islist": "YES",
+						"items": [
+							{
+								"text": [
+									"You gain a +1 bonus to attack rolls you make with the weapon."
+								]
+							},
+							{
+								"text": [
+									"Whenever you have advantage on a melee attack roll you make with the weapon and hit, you can knock the target prone if the lower of the two d20 rolls would also hit the target."
+								]
+							},
+							{
+								"text": [
+									"Whenever you have disadvantage on a melee attack roll you make with the weapon, the target takes bludgeoning damage equal to your Strength modifier (minimum of 0) if the attack misses but the higher of the two d20 rolls would have hit."
+								]
+							},
+							{
+								"text": [
+									"If you use the Help action to aid an ally's melee attack while you're wielding the weapon, you knock the target's shield aside momentarily. In addition to the ally gaining advantage on the attack roll, the ally gains a +2 bonus to the roll if the target is using a shield."
+								]
+							}
+						]
+					}
+				]
+			},
+			{
 				"name": "Barbed Hide",
 				"prerequisite": [
 					{
@@ -1240,38 +1272,6 @@ var featdata =
 				"ability": {
 					"int": 1
 				}
-			},
-			{
-				"name": "Fell Handed",
-				"source": "UAFT",
-				"text": [
-					"You master the handaxe, battleaxe, greataxe, warhammer, and maul. You gain the following benefits when using any of them:",
-					{
-						"islist": "YES",
-						"items": [
-							{
-								"text": [
-									"You gain a +1 bonus to attack rolls you make with the weapon."
-								]
-							},
-							{
-								"text": [
-									"Whenever you have advantage on a melee attack roll you make with the weapon and hit, you can knock the target prone if the lower of the two d20 rolls would also hit the target."
-								]
-							},
-							{
-								"text": [
-									"Whenever you have disadvantage on a melee attack roll you make with the weapon, the target takes bludgeoning damage equal to your Strength modifier (minimum of 0) if the attack misses but the higher of the two d20 rolls would have hit."
-								]
-							},
-							{
-								"text": [
-									"If you use the Help action to aid an ally's melee attack while you're wielding the weapon, you knock the target's shield aside momentarily. In addition to the ally gaining advantage on the attack roll, the ally gains a +2 bonus to the roll if the target is using a shield."
-								]
-							}
-						]
-					}
-				]
 			},
 			{
 				"name": "Blade Mastery",

--- a/data/races.json
+++ b/data/races.json
@@ -3144,7 +3144,7 @@ var racedata =
 					{
 						"name": "Blood Thirst",
 						"text": [
-							"You can drain blood and life energy from a willing creature, or one that is grappled by you, incapacitated, or restrained. Make a melee attack against the target. If you hit, you deal 1 piercing damage and 1d6 necrotic damage. The target's hit point maximum is reduced by an amount equal to the necrotic damage taken, and you regain hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0. A humanoid killed in this way becomes a null (see â€œA Zendikar Bestiaryâ€)."
+							"You can drain blood and life energy from a willing creature, or one that is grappled by you, incapacitated, or restrained. Make a melee attack against the target. If you hit, you deal 1 piercing damage and 1d6 necrotic damage. The target's hit point maximum is reduced by an amount equal to the necrotic damage taken, and you regain hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0. A humanoid killed in this way becomes a null (see \"Zendikar Bestiary\")."
 						]
 					},
 					{

--- a/js/history.js
+++ b/js/history.js
@@ -2,7 +2,9 @@ window.onhashchange = function hashchange(e) {
 	const [link, sub] = window.location.hash.slice(1).split(',');
 
 	if (!e || !sub) {
-		const $el = $(`#listcontainer a[href='#${link.toLowerCase()}']`);
+		let $el = $(`#listcontainer a[href='#${link.toLowerCase()}']`);
+		//For some reason the above does not work for Backgrounds, so this is a TEMPORARY work-around
+		if($el.attr("id") === undefined) {$el = $(`ul.list li[data-link='${link.toLowerCase()}']:eq(0)`)}
 		loadhash($el.attr("id"));
 		document.title = decodeURIComponent($el.attr("title")) + " - 5etools";
 	}


### PR DESCRIPTION
bestiary.json
Replaced "languages": "\u2014" with "languages": "", '| |' with '||' in the "attack" data, yuan-ti with Yuan-ti, and yuan-ti with yuan-ti
Fixed Avatar of Death's HP per DMG p164, Chwinga's AC, Geist's ability scores, and Nereid's Skills
Partially fixed Snarla's Type/Alignment

bestiary-tob.json
Added "level " to the Spellcasting data for Alseid Grovekeeper
Removed extra whitespace
Replaced ; with : in Young Cave Dragon's Multiattack data
Fixed Fext's Constitution and the abilities for Zmey Headling, Coral Drake, and Chronalmental

feats.json
Moved Fell Handed to the top of the file so that "Unearthed Arcana: Feats" would get added to the Sources drop-down.

races.json
Replaced strange characters in Vampire with ".