### PR TITLE
chore(eslint): add rule to prefer const declarations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,23 +1,30 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "es6": true
-    },
-    "globals": {
-        "$": true,
-        "droll": true,
-    },
-    "rules": {
-        "no-console": 2,
-        "no-extra-semi": 2,
-        "no-inner-declarations": 2,
-        "no-mixed-spaces-and-tabs": 2,
-        "no-redeclare": 2,
-        "no-unreachable": 2,
+	"env": {
+		"browser": true,
+		"es6": true
+	},
+	"globals": {
+		"$": true,
+		"droll": true,
+	},
+	"rules": {
+		"no-console": 2,
+		"no-extra-semi": 2,
+		"no-inner-declarations": 2,
+		"no-mixed-spaces-and-tabs": 2,
+		"no-redeclare": 2,
+		"no-unreachable": 2,
+		"prefer-const": [
+			"warn",
+			{
+				"destructuring": "any",
+				"ignoreReadBeforeAssign": false
+			}
+		],
 
-        "indent": [
-            "error",
-            "tab"
-        ]
-    }
-};
+		"indent": [
+			"error",
+			"tab"
+		]
+	}
+}


### PR DESCRIPTION
This PR adds the `prefer-const` rule to the eslint config, and also converts that file from spaces to tabs.