### PR TITLE
fix (feats) Removed reference to non-existent rule.

### DIFF
--- a/data/feats.json
+++ b/data/feats.json
@@ -1705,8 +1705,7 @@
 					"items": [
 						"You have advantage on Wisdom (Perception) and Intelligence (Investigation) checks made to detect the presence of secret doors.",
 						"You have advantage on saving throws made to avoid or resist traps.",
-						"You have resistance to the damage dealt by traps.",
-						"You can search for traps while traveling at a normal pace, instead of only at a slow pace."
+						"You have resistance to the damage dealt by traps."
 					]
 				}
 			]


### PR DESCRIPTION
From October 2017's [Sage Advice](https://media.wizards.com/2017/dnd/downloads/SA-Compendium.pdf):
"**The Dungeon Delver feat talks about searching for traps
 at a normal or slow pace. Where’s the rule on this?** The
 final benefit of the Dungeon Delver feat refers to a nonexistent
 rule (from the 5E playtest). Ignore it. We’ll cut it in a
 future printing of the Player’s Handbook."