### PR TITLE
(feat) lootgen Adding links to items, part 1; (chore) refactoring

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -8,7 +8,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"An opaque mottled deep blue gemstone worth 10 gp."
+				"An opaque mottled deep blue gemstone."
 			]
 		},
 		{
@@ -19,7 +19,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A translucent striped brown, blue, white, or red gemstone worth 10 gp."
+				"A translucent striped brown, blue, white, or red gemstone."
 			]
 		},
 		{
@@ -30,7 +30,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent pale blue gemstone worth 10 gp."
+				"A transparent pale blue gemstone."
 			]
 		},
 		{
@@ -41,7 +41,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A translucent circles of gray, white, brown, blue, or green gemstone worth 10 gp."
+				"A translucent circles of gray, white, brown, blue, or green gemstone."
 			]
 		},
 		{
@@ -52,7 +52,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"An opaque gray-black gemstone worth 10 gp."
+				"An opaque gray-black gemstone."
 			]
 		},
 		{
@@ -63,7 +63,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"An opaque light and dark blue with yellow flecks gemstone worth 10 gp."
+				"An opaque light and dark blue with yellow flecks gemstone."
 			]
 		},
 		{
@@ -74,7 +74,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"An opaque striated light and dark green gemstone worth 10 gp."
+				"An opaque striated light and dark green gemstone."
 			]
 		},
 		{
@@ -85,7 +85,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A translucent pink or yellow-white with mossy gray or green markings gemstone worth 10 gp."
+				"A translucent pink or yellow-white with mossy gray or green markings gemstone."
 			]
 		},
 		{
@@ -96,7 +96,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"An opaque black gemstone worth 10 gp."
+				"An opaque black gemstone."
 			]
 		},
 		{
@@ -107,7 +107,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"An opaque light pink gemstone worth 10 gp."
+				"An opaque light pink gemstone."
 			]
 		},
 		{
@@ -118,7 +118,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A translucent brown with golden center gemstone worth 10 gp."
+				"A translucent brown with golden center gemstone."
 			]
 		},
 		{
@@ -129,7 +129,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"An opaque light blue-green gemstone worth 10 gp."
+				"An opaque light blue-green gemstone."
 			]
 		},
 		{
@@ -140,7 +140,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent watery gold to rich gold gemstone worth 100 gp."
+				"A transparent watery gold to rich gold gemstone."
 			]
 		},
 		{
@@ -151,7 +151,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent deep purple gemstone worth 100 gp."
+				"A transparent deep purple gemstone."
 			]
 		},
 		{
@@ -162,7 +162,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent yellow-green to pale green gemstone worth 100 gp."
+				"A transparent yellow-green to pale green gemstone."
 			]
 		},
 		{
@@ -173,7 +173,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"An opaque crimson gemstone worth 100 gp."
+				"An opaque crimson gemstone."
 			]
 		},
 		{
@@ -184,7 +184,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent red, brown-green, or violet gemstone worth 100 gp."
+				"A transparent red, brown-green, or violet gemstone."
 			]
 		},
 		{
@@ -195,7 +195,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A translucent light green, deep green, or white gemstone worth 100 gp."
+				"A translucent light green, deep green, or white gemstone."
 			]
 		},
 		{
@@ -206,7 +206,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"An opaque deep black gemstone worth 100 gp."
+				"An opaque deep black gemstone."
 			]
 		},
 		{
@@ -217,7 +217,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"An opaque lustrous white, yellow, or pink gemstone worth 100 gp."
+				"An opaque lustrous white, yellow, or pink gemstone."
 			]
 		},
 		{
@@ -228,7 +228,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent red, red-brown, or deep green gemstone worth 100 gp."
+				"A transparent red, red-brown, or deep green gemstone."
 			]
 		},
 		{
@@ -239,7 +239,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent pale green, blue, brown, or red gemstone worth 100 gp."
+				"A transparent pale green, blue, brown, or red gemstone."
 			]
 		},
 		{
@@ -250,7 +250,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A translucent dark green with black mottling and golden flecks gemstone worth 1000 gp."
+				"A translucent dark green with black mottling and golden flecks gemstone."
 			]
 		},
 		{
@@ -261,7 +261,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent blue-white to medium blue gemstone worth 1000 gp."
+				"A transparent blue-white to medium blue gemstone."
 			]
 		},
 		{
@@ -272,7 +272,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent deep bright green gemstone worth 1000 gp."
+				"A transparent deep bright green gemstone."
 			]
 		},
 		{
@@ -283,7 +283,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A translucent fiery red gemstone worth 1000 gp."
+				"A translucent fiery red gemstone worth."
 			]
 		},
 		{
@@ -294,7 +294,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A translucent pale blue with green and golden mottling gemstone worth 1000 gp."
+				"A translucent pale blue with green and golden mottling gemstone."
 			]
 		},
 		{
@@ -305,7 +305,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A translucent ruby with white star-shaped center gemstone worth 1000 gp."
+				"A translucent ruby with white star-shaped center gemstone."
 			]
 		},
 		{
@@ -316,7 +316,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A translucent blue sapphire with white star-shaped center gemstone worth 1000 gp."
+				"A translucent blue sapphire with white star-shaped center gemstone."
 			]
 		},
 		{
@@ -327,7 +327,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent fiery yellow or yellow-green gemstone worth 1000 gp."
+				"A transparent fiery yellow or yellow-green gemstone."
 			]
 		},
 		{
@@ -336,10 +336,7 @@
 			"rarity": "None",
 			"value": "25gp",
 			"source": "DMG",
-			"page": "134",
-			"entries": [
-				"This art object is worth 25 gp."
-			]
+			"page": "134"
 		},
 		{
 			"name": "Carved bone statuette",
@@ -347,10 +344,7 @@
 			"rarity": "None",
 			"value": "25gp",
 			"source": "DMG",
-			"page": "134",
-			"entries": [
-				"This art object is worth 25 gp."
-			]
+			"page": "134"
 		},
 		{
 			"name": "Cloth-of-gold vestments",
@@ -358,10 +352,7 @@
 			"rarity": "None",
 			"value": "25gp",
 			"source": "DMG",
-			"page": "134",
-			"entries": [
-				"This art object is worth 25 gp."
-			]
+			"page": "134"
 		},
 		{
 			"name": "Copper chalice with silver filigree",
@@ -369,10 +360,7 @@
 			"rarity": "None",
 			"value": "25gp",
 			"source": "DMG",
-			"page": "134",
-			"entries": [
-				"This art object is worth 25 gp."
-			]
+			"page": "134"
 		},
 		{
 			"name": "Embroidered silk handkerchief",
@@ -380,10 +368,7 @@
 			"rarity": "None",
 			"value": "25gp",
 			"source": "DMG",
-			"page": "134",
-			"entries": [
-				"This art object is worth 25 gp."
-			]
+			"page": "134"
 		},
 		{
 			"name": "Gold locket with a painted portrait inside",
@@ -391,10 +376,7 @@
 			"rarity": "None",
 			"value": "25gp",
 			"source": "DMG",
-			"page": "134",
-			"entries": [
-				"This art object is worth 25 gp."
-			]
+			"page": "134"
 		},
 		{
 			"name": "Pair of engraved bone dice",
@@ -402,10 +384,7 @@
 			"rarity": "None",
 			"value": "25gp",
 			"source": "DMG",
-			"page": "134",
-			"entries": [
-				"This art object is worth 25 gp."
-			]
+			"page": "134"
 		},
 		{
 			"name": "Silver ewer",
@@ -413,10 +392,7 @@
 			"rarity": "None",
 			"value": "25gp",
 			"source": "DMG",
-			"page": "134",
-			"entries": [
-				"This art object is worth 25 gp."
-			]
+			"page": "134"
 		},
 		{
 			"name": "Small gold bracelet",
@@ -424,10 +400,7 @@
 			"rarity": "None",
 			"value": "25gp",
 			"source": "DMG",
-			"page": "134",
-			"entries": [
-				"This art object is worth 25 gp."
-			]
+			"page": "134"
 		},
 		{
 			"name": "Small mirror set in a painted wooden frame",
@@ -435,10 +408,7 @@
 			"rarity": "None",
 			"value": "25gp",
 			"source": "DMG",
-			"page": "134",
-			"entries": [
-				"This art object is worth 25 gp."
-			]
+			"page": "134"
 		},
 		{
 			"name": "Box of turquoise animal figurines",
@@ -446,10 +416,7 @@
 			"rarity": "None",
 			"value": "250gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 250 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Brass mug with jade inlay",
@@ -457,10 +424,7 @@
 			"rarity": "None",
 			"value": "250gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 250 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Bronze crown",
@@ -468,10 +432,7 @@
 			"rarity": "None",
 			"value": "250gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 250 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Carved ivory statuette",
@@ -479,10 +440,7 @@
 			"rarity": "None",
 			"value": "250gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 250 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Gold bird cage with electrum filigree",
@@ -490,10 +448,7 @@
 			"rarity": "None",
 			"value": "250gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 250 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Gold ring set with bloodstones",
@@ -501,10 +456,7 @@
 			"rarity": "None",
 			"value": "250gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 250 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Large gold bracelet",
@@ -512,10 +464,7 @@
 			"rarity": "None",
 			"value": "250gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 250 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Large well-made tapestry",
@@ -523,10 +472,7 @@
 			"rarity": "None",
 			"value": "250gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 250 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Silk robe with gold embroidery",
@@ -534,10 +480,7 @@
 			"rarity": "None",
 			"value": "250gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 250 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Silver necklace with a gemstone pendant",
@@ -545,10 +488,7 @@
 			"rarity": "None",
 			"value": "250gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 250 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Necklace string of small pink pearls",
@@ -556,10 +496,7 @@
 			"rarity": "None",
 			"value": "2500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 2500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Embroidered glove set with jewel chips",
@@ -567,10 +504,7 @@
 			"rarity": "None",
 			"value": "2500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 2500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Embroidered silk and velvet mantle set with numerous moonstones",
@@ -578,10 +512,7 @@
 			"rarity": "None",
 			"value": "2500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 2500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Eye patch with a mock eye set in blue sapphire and moonstone",
@@ -589,10 +520,7 @@
 			"rarity": "None",
 			"value": "2500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 2500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Fine gold chain set with a fire opal",
@@ -600,10 +528,7 @@
 			"rarity": "None",
 			"value": "2500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 2500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Gold circlet set with four aquamarines",
@@ -611,10 +536,7 @@
 			"rarity": "None",
 			"value": "2500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 2500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Gold music box",
@@ -622,10 +544,7 @@
 			"rarity": "None",
 			"value": "2500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 2500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Jeweled anklet",
@@ -633,10 +552,7 @@
 			"rarity": "None",
 			"value": "2500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 2500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Old masterpiece painting",
@@ -644,10 +560,7 @@
 			"rarity": "None",
 			"value": "2500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 2500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Platinum bracelet set with a sapphire",
@@ -655,10 +568,7 @@
 			"rarity": "None",
 			"value": "2500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 2500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Bloodstone",
@@ -668,7 +578,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"An opaque dark gray with red flecks gemstone worth 50 gp."
+				"An opaque dark gray with red flecks gemstone."
 			]
 		},
 		{
@@ -679,7 +589,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"An opaque orange to red-brown gemstone worth 50 gp."
+				"An opaque orange to red-brown gemstone."
 			]
 		},
 		{
@@ -690,7 +600,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"An opaque white gemstone worth 50 gp."
+				"An opaque white gemstone."
 			]
 		},
 		{
@@ -701,7 +611,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A translucent green gemstone worth 50 gp."
+				"A translucent green gemstone."
 			]
 		},
 		{
@@ -712,7 +622,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent pale yellow-brown gemstone worth 50 gp."
+				"A transparent pale yellow-brown gemstone."
 			]
 		},
 		{
@@ -723,7 +633,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"An opaque blue, black, or brown gemstone worth 50 gp."
+				"An opaque blue, black, or brown gemstone."
 			]
 		},
 		{
@@ -734,7 +644,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A translucent white with pale blue glow gemstone worth 50 gp."
+				"A translucent white with pale blue glow gemstone."
 			]
 		},
 		{
@@ -745,7 +655,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"An opaque bands of black and white, or pure black or white gemstone worth 50 gp."
+				"An opaque black and white banded, or pure black or white gemstone."
 			]
 		},
 		{
@@ -756,7 +666,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent white, smoky gray, or yellow gemstone worth 50 gp."
+				"A transparent white, smoky gray, or yellow gemstone."
 			]
 		},
 		{
@@ -767,7 +677,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"An opaque bands of red and white gemstone worth 50 gp."
+				"An opaque bands of red and white gemstone."
 			]
 		},
 		{
@@ -778,7 +688,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A translucent rosy stone with white star-shaped center gemstone worth 50 gp."
+				"A translucent rosy stone with white star-shaped center gemstone."
 			]
 		},
 		{
@@ -789,7 +699,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent pale blue-green gemstone worth 50 gp."
+				"A transparent pale blue-green gemstone."
 			]
 		},
 		{
@@ -800,7 +710,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent dark green gemstone worth 500 gp."
+				"A transparent dark green gemstone."
 			]
 		},
 		{
@@ -811,7 +721,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent pale blue-green gemstone worth 500 gp."
+				"A transparent pale blue-green gemstone."
 			]
 		},
 		{
@@ -822,7 +732,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"An opaque pure black gemstone worth 500 gp."
+				"An opaque pure black gemstone."
 			]
 		},
 		{
@@ -833,7 +743,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent deep blue gemstone worth 500 gp."
+				"A transparent deep blue gemstone."
 			]
 		},
 		{
@@ -844,7 +754,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent rich olive green gemstone worth 500 gp."
+				"A transparent rich olive green gemstone."
 			]
 		},
 		{
@@ -855,7 +765,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent golden yellow gemstone worth 500 gp."
+				"A transparent golden yellow gemstone."
 			]
 		},
 		{
@@ -866,7 +776,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A translucent lustrous black with glowing highlights gemstone worth 5000 gp."
+				"A translucent lustrous black with glowing highlights gemstone."
 			]
 		},
 		{
@@ -877,7 +787,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent blue-white, canary, pink, brown, or blue gemstone worth 5000 gp."
+				"A transparent blue-white, canary, pink, brown, or blue gemstone."
 			]
 		},
 		{
@@ -888,7 +798,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent fiery orange gemstone worth 5000 gp."
+				"A transparent fiery orange gemstone."
 			]
 		},
 		{
@@ -899,7 +809,7 @@
 			"source": "DMG",
 			"page": "134",
 			"entries": [
-				"A transparent clear red to deep crimson gemstone worth 5000 gp."
+				"A transparent clear red to deep crimson gemstone."
 			]
 		},
 		{
@@ -908,10 +818,7 @@
 			"rarity": "None",
 			"value": "750gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 750 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Carved harp of exotic wood with ivory inlay and zircon gems",
@@ -919,10 +826,7 @@
 			"rarity": "None",
 			"value": "750gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 750 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Ceremonial electrum dagger with a black pearl in the pommel",
@@ -930,10 +834,7 @@
 			"rarity": "None",
 			"value": "750gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 750 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Gold dragon comb set with red garnets as eyes",
@@ -941,10 +842,7 @@
 			"rarity": "None",
 			"value": "750gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 750 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Obsidian statuette with gold fittings and inlay",
@@ -952,10 +850,7 @@
 			"rarity": "None",
 			"value": "750gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 750 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Painted gold war mask",
@@ -963,10 +858,7 @@
 			"rarity": "None",
 			"value": "750gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 750 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Silver and gold brooch",
@@ -974,10 +866,7 @@
 			"rarity": "None",
 			"value": "750gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 750 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Silver chalice set with moonstones",
@@ -985,10 +874,7 @@
 			"rarity": "None",
 			"value": "750gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 750 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Silver-plated steel longsword with jet set in hilt",
@@ -996,10 +882,7 @@
 			"rarity": "None",
 			"value": "750gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 750 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Small gold idol",
@@ -1007,10 +890,7 @@
 			"rarity": "None",
 			"value": "750gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 750 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Bejeweled ivory drinking horn with gold filigree",
@@ -1018,10 +898,7 @@
 			"rarity": "None",
 			"value": "7500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 7500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Gold cup set with emeralds",
@@ -1029,10 +906,7 @@
 			"rarity": "None",
 			"value": "7500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 7500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Gold jewelry box with platinum filigree",
@@ -1040,10 +914,7 @@
 			"rarity": "None",
 			"value": "7500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 7500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Jade game board with solid gold playing pieces",
@@ -1051,10 +922,7 @@
 			"rarity": "None",
 			"value": "7500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 7500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Jeweled gold crown",
@@ -1062,10 +930,7 @@
 			"rarity": "None",
 			"value": "7500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 7500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Jeweled platinum ring",
@@ -1073,10 +938,7 @@
 			"rarity": "None",
 			"value": "7500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 7500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Painted gold child's sarcophagus",
@@ -1084,10 +946,7 @@
 			"rarity": "None",
 			"value": "7500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 7500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Small gold statuette set with rubies",
@@ -1095,10 +954,7 @@
 			"rarity": "None",
 			"value": "7500gp",
 			"source": "DMG",
-			"page": "135",
-			"entries": [
-				"This art object is worth 7500 gp."
-			]
+			"page": "135"
 		},
 		{
 			"name": "Abacus",
@@ -1478,22 +1334,68 @@
 			"reqAttune": "YES",
 			"entries": [
 				"Seeing the peril his people faced, a young dwarf prince came to believe that his people needed something to unite them. Thus, he set out to forge a weapon that would be such a symbol.",
-				"Venturing deep under the mountains, deeper than any dwarf had ever delved, the young prince came to the blazing heart of a great volcano. With the aid of Moradin, the dwarven god of creation, he first crafted four great tools: the Brutal Pick, the Earthheart Forge, the Anvil of Songs, and the Shaping Hammer. With them, he forged the Axe of the Dwarvish Lords.",
+				"Venturing deep under the mountains, deeper than any dwarf had ever delved, the young prince came to the blazing heart of a great volcano. With the aid of Moradin, the dwarven god of creation, he first crafted four great tools: the {@italic Brutal Pick}, the {@italic Earthheart Forge}, the {@italic Anvil of Songs}, and the {@italic Shaping Hammer}. With them, he forged the {@italic Axe of the Dwarvish Lords}.",
 				"Armed with the artifact, the prince returned to the dwarf clans and brought peace. His axe ended grudges and answered slights. The clans became allies, and they threw back their enemies and enjoyed an era of prosperity. This young dwarf is remembered as the First King. When he became old, he passed the weapon, which had become his badge of office, to his heir. The rightful inheritors passed the axe on for many generations.",
 				"Later, in a dark era marked by treachery and wickedness, the axe was lost in a bloody civil war fomented by greed for its power and the status it bestowed. Centuries later, the dwarves still search for the axe, and many adventurers have made careers of chasing after rumors and plundering old vaults to find it.",
-				"Magic Weapon. The Axe of the Dwarvish Lords is a magic weapon that grants a +3 bonus to attack and damage rolls made with it. The axe also functions as a belt of dwarvenkind, a dwarven thrower, and a sword of sharpness.",
-				"Random Properties. The axe has the following randomly determined properties:",
-				"• 2 minor beneficial properties",
-				"• 1 major beneficial property",
-				"• 2 minor detrimental properties",
-				"Blessings of Moradin. If you are a dwarf attuned to the axe, you gain the following benefits:",
-				"• You have immunity to poison damage.",
-				"• The range of your darkvision increases by 60 feet.",
-				"• You gain proficiency with artisan's tools related to blacksmithing, brewing, and stonemasonry.",
-				"Conjure Earth Elemental. If you are holding the axe, you can use your action to cast the {@spell conjure elemental|phb} spell from it, summoning an <a href=\"bestiary.html#earth%20elemental_mm\" target=\"_blank\">earth elemental</a>. You can't use this property again until the next dawn.",
-				"Travel the Depths. You can use an action to touch the axe to a fixed piece of dwarven stonework and cast the {@spell teleport|phb} spell from the axe. If your intended destination is underground, there is no chance of a mishap or arriving somewhere unexpected. You can't use this property again until 3 days have passed.",
-				"Curse. The axe bears a curse that affects any non-dwarf that becomes attuned to it. Even if the attunement ends, the curse remains. With each passing day, the creature's physical appearance and stature become more dwarflike. After seven days, the creature looks like a typical dwarf, but the creature neither loses its racial traits nor gains the racial traits of a dwarf. The physical changes wrought by the axe aren't considered magical in nature (and therefore can't be dispelled), but they can be undone by any effect that removes a curse, such as a {@spell greater restoration|phb} or {@spell remove curse|phb} spell.",
-				"Destroying the Axe. The only way to destroy the axe is to melt it down in the Earthheart Forge, where it was created. It must remain in the burning forge for fifty years before it finally succumbs to the fire and is consumed."
+				"Magic Weapon. The {@italic Axe of the Dwarvish Lords} is a magic weapon that grants a +3 bonus to attack and damage rolls made with it. The axe also functions as a {@item belt of dwarvenkind|dmg}, a {@item dwarven thrower}, and a {@item sword of sharpness}.",
+				{
+					"type": "entries",
+					"name": "Random Properties",
+					"entries": [
+						"The axe has the following randomly determined properties:",
+						{
+							"type": "list",
+							"items": [
+								"2 minor beneficial properties",
+								"1 major beneficial property",
+								"2 minor detrimental properties"
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Blessings of Moradin",
+					"entries": [
+						"If you are a dwarf attuned to the axe, you gain the following benefits:",
+						{
+							"type": "list",
+							"items": [
+								"You have immunity to poison damage.",
+								"The range of your darkvision increases by 60 feet.",
+								"You gain proficiency with artisan's tools related to blacksmithing, brewing, and stonemasonry."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Conjure Earth Elemental",
+					"entries": [
+						"If you are holding the axe, you can use your action to cast the {@spell conjure elemental|phb} spell from it, summoning an {@creature earth elemental|mm}. You can't use this property again until the next dawn."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Travel the Depths",
+					"entries": [
+						"You can use an action to touch the axe to a fixed piece of dwarven stonework and cast the {@spell teleport|phb} spell from the axe. If your intended destination is underground, there is no chance of a mishap or arriving somewhere unexpected. You can't use this property again until 3 days have passed."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Curse",
+					"entries": [
+						"The axe bears a curse that affects any non-dwarf that becomes attuned to it. Even if the attunement ends, the curse remains. With each passing day, the creature's physical appearance and stature become more dwarflike. After seven days, the creature looks like a typical dwarf, but the creature neither loses its racial traits nor gains the racial traits of a dwarf. The physical changes wrought by the axe aren't considered magical in nature (and therefore can't be dispelled), but they can be undone by any effect that removes a curse, such as a {@spell greater restoration|phb} or {@spell remove curse|phb} spell."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Destroying the Axe",
+					"entries": [
+						"The only way to destroy the axe is to melt it down in the {@italic Earthheart Forge}, where it was created. It must remain in the burning forge for fifty years before it finally succumbs to the fire and is consumed."
+					]
+				}
 			],
 			"modifier": [
 				{
@@ -2861,7 +2763,7 @@
 				"• You have a climbing speed equal to your walking speed.",
 				"• You can move up, down, and across vertical surfaces and upside down along ceilings, while leaving your hands free.",
 				"• You can't be caught in webs of any sort and can move through webs as if they were difficult terrain.",
-				"• You can use an action to cast the <a href=\"spells.html#web_phb\" target=\"_blank\">web</a> spell (save DC 13). The web created by the spell fills twice its normal area. Once used, this property of the cloak can't be used again until the next dawn."
+				"• You can use an action to cast the {@spell web|phb} spell (save DC 13). The web created by the spell fills twice its normal area. Once used, this property of the cloak can't be used again until the next dawn."
 			]
 		},
 		{
@@ -2922,7 +2824,7 @@
 			"reqAttune": "YES",
 			"entries": [
 				"While wearing this cloak, you have advantage on Dexterity (Stealth) checks. In an area of dim light or darkness, you can grip the edges of the cloak with both hands and use it to fly at a speed of 40 feet. If you ever fail to grip the cloak's edges while flying in this way, or if you are no longer in dim light or darkness, you lose this flying speed.",
-				"While wearing the cloak in an area of dim light or darkness, you can use your action to cast <a href=\"spells.html#polymorph_phb\" target=\"_blank\">polymorph</a> on yourself, transforming into a bat. While you are in the form of the bat, you retain your Intelligence, Wisdom, and Charisma scores. The cloak can't be used this way again until the next dawn."
+				"While wearing the cloak in an area of dim light or darkness, you can use your action to cast {@spell polymorph|phb} on yourself, transforming into a bat. While you are in the form of the bat, you retain your Intelligence, Wisdom, and Charisma scores. The cloak can't be used this way again until the next dawn."
 			]
 		},
 		{
@@ -3100,7 +3002,7 @@
 			"reqAttune": "YES",
 			"entries": [
 				"This crystal ball is about 6 inches in diameter. While touching it, you can cast the {@spell scrying|phb} spell (save DC 17) with it.",
-				"You can use an action to cast the <a href=\"spells.html#detect%20thoughts_phb\" target=\"_blank\">detect thoughts</a> spell (save DC 17) while you are {@spell scrying|phb} with the crystal ball, targeting creatures you can see within 30 feet of the spell's sensor. You don't need to concentrate on this <a href=\"spells.html#detect%20thoughts_phb\" target=\"_blank\">detect thoughts</a> to maintain it during its duration, but it ends if {@spell scrying|phb} ends."
+				"You can use an action to cast the {@spell detect thoughts|phb} spell (save DC 17) while you are {@spell scrying|phb} with the crystal ball, targeting creatures you can see within 30 feet of the spell's sensor. You don't need to concentrate on this {@spell detect thoughts|phb} to maintain it during its duration, but it ends if {@spell scrying|phb} ends."
 			]
 		},
 		{
@@ -3114,7 +3016,7 @@
 			"reqAttune": "YES",
 			"entries": [
 				"This crystal ball is about 6 inches in diameter. While touching it, you can cast the {@spell scrying|phb} spell (save DC 17) with it.",
-				"While {@spell scrying|phb} with the crystal ball, you can communicate telepathically with creatures you can see within 30 feet of the spell's sensor. You can also use an action to cast the <a href=\"spells.html#suggestion_phb\" target=\"_blank\">suggestion</a> spell (save DC 17) through the sensor on one of those creatures. You don't need to concentrate on this suggestion to maintain it during its duration, but it ends if {@spell scrying|phb} ends. Once used, the suggestion power of the crystal ball can't be used again until the next dawn."
+				"While {@spell scrying|phb} with the crystal ball, you can communicate telepathically with creatures you can see within 30 feet of the spell's sensor. You can also use an action to cast the {@spell suggestion|phb} spell (save DC 17) through the sensor on one of those creatures. You don't need to concentrate on this suggestion to maintain it during its duration, but it ends if {@spell scrying|phb} ends. Once used, the suggestion power of the crystal ball can't be used again until the next dawn."
 			]
 		},
 		{
@@ -3201,7 +3103,7 @@
 					],
 					"rows": [
 						[
-							"<a href=\"spells.html#disintegrate_phb\" target=\"_blank\">Disintegrate</a>",
+							"{@spell disintegrate|phb|Disintegrate}",
 							"1d12"
 						],
 						[
@@ -3209,15 +3111,15 @@
 							"1d10"
 						],
 						[
-							"<a href=\"spells.html#passwall_phb\" target=\"_blank\">Passwall</a>",
+							"{@spell passwall|phb|Passwall}",
 							"1d6"
 						],
 						[
-							"<a href=\"spells.html#prismatic%20spray_phb\" target=\"_blank\">Prismatic spray</a>",
+							"{@spell prismatic spray|phb|Prismatic spray}",
 							"1d20"
 						],
 						[
-							"<a href=\"spells.html#wall%20of%20fire_phb\" target=\"_blank\">Wall of fire</a>",
+							"{@spell wall of fire|phb|Wall of fire}",
 							"1d4"
 						]
 					]
@@ -3246,7 +3148,7 @@
 			"page": "160",
 			"entries": [
 				"You can use an action to place this 1-inch metal cube on the ground and speak its command word. The cube rapidly grows into a fortress that remains until you use an action to speak the command word that dismisses it, which works only if the fortress is empty.",
-				"The fortress is a square tower, 20 feet on a side and 30 feet high, with arrow slits on all sides and a battlement atop it. Its interior is divided into two floors. with a ladder running along one wall to connect them. The ladder ends at a trapdoor leading to the roof. When activated, the tower has a small door on the side facing you. The door opens only at your command, which you can speak as a bonus action. It is immune to the <a href=\"spells.html#knock_phb\" target=\"_blank\">knock</a> spell and similar magic, such as that of a chime of opening.",
+				"The fortress is a square tower, 20 feet on a side and 30 feet high, with arrow slits on all sides and a battlement atop it. Its interior is divided into two floors. with a ladder running along one wall to connect them. The ladder ends at a trapdoor leading to the roof. When activated, the tower has a small door on the side facing you. The door opens only at your command, which you can speak as a bonus action. It is immune to the {@spell knock|phb} spell and similar magic, such as that of a chime of opening.",
 				"Each creature in the area where the fortress appears must make a DC 15 Dexterity saving throw, taking 10d10 bludgeoning damage on a failed save, or half as much damage on a successful one. In either case, the creature is pushed to an unoccupied space outside but next to the fortress. Objects in the area that aren't being worn or carried take this damage and are pushed automatically.",
 				"The tower is made of adamantine, and its magic prevents it from being tipped over. The roof, the door, and the walls each have 100 hit points, immunity to damage from nonmagical weapons excluding siege weapons, and resistance to all other damage. Only a {@spell wish|phb} spell can repair the fortress (this use of the spell counts as replicating a spell of 8th level or lower). Each casting of {@spell wish|phb} causes the roof, the door, or one wall to regain 50 hit points."
 			]
@@ -3286,7 +3188,7 @@
 				"Lost for ages in the Underdark, Dawnbringer appears to be a gilded longsword hilt. While grasping the hilt, you can use a bonus action to make a blade of pure radiance spring from the hilt, or cause the blade to disappear. While the blade exists, this magic longsword has the finesse property. If you are proficient with shortswords or longswords, you are proficient with Dawnbringer.",
 				"You gain a +2 bonus to attack and damage rolls made with this weapon, which deals radiant damage instead of slashing damage. When you hit an undead with it, that target takes an extra 1d8 radiant damage.",
 				"The sword's luminous blade emits bright light in a 15-foot radius and dim light for an additional 15 feet. The light is sunlight. While the blade persists, you can use an action to expand or reduce its radius of bright and dim light by 5 feet each, to a maximum of 30 feet each or a minimum of 10 feet each.",
-				"While holding the weapon, you can use an action to touch a creature with the blade and cast <a href=\"spells.html#lesser%20restoration_phb\" target=\"_blank\">lesser restoration</a> on that creature. Once used, this ability can't be used again until the next dawn.",
+				"While holding the weapon, you can use an action to touch a creature with the blade and cast {@spell lesser restoration|phb} on that creature. Once used, this ability can't be used again until the next dawn.",
 				"Sentience. Dawnbringer is a sentient neutral good weapon with an Intelligence of 12, a Wisdom of 15, and a Charisma of 14. It has hearing and darkvision out to a range of 120 feet.",
 				"The sword can speak, read, and understand Common, and it can communicate with its wielder telepathically. Its voice is kind and feminine. It knows every language you know while attuned to it.",
 				"Personality. Forged by ancient sun worshippers, Dawnbringer is meant to bring light into darkness and to fight creatures of darkness. It is kind and compassionate to those in need, but fierce and destructive to its enemies.",
@@ -3649,7 +3551,7 @@
 				"A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as identify and divination can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.",
 				"A special container can be crafted to contain a devastation orb and prevent it from detonating. The container must be inscribed with symbols of the orb's opposing element. For example, a case inscribed with earth symbols can be used to contain a devastation orb of air and keep it from detonating. While in the container, the orb thrums. If it is removed from the container after the time when it was supposed to detonate, it explodes 1d6 rounds later, unless it is returned to the container.",
 				"Regardless of the type of orb, its effect is contained within a sphere with a 1 mile radius. The orb is the sphere's point of origin. The orb is destroyed after one use.",
-				"Earth Orb. When this orb detonates, it subjects the area to the effects of the <a href=\"spells.html#earthquake_phb\" target=\"_blank\">earthquake</a> spell for 1 minute (spell save DC 18). For the purpose of the spell's effects, the spell is cast on the turn that the orb explodes."
+				"Earth Orb. When this orb detonates, it subjects the area to the effects of the {@spell earthquake|phb} spell for 1 minute (spell save DC 18). For the purpose of the spell's effects, the spell is cast on the turn that the orb explodes."
 			]
 		},
 		{
@@ -3674,7 +3576,7 @@
 			"page": "222",
 			"entries": [
 				"A devastation orb is an elemental bomb that can be created at the site of an elemental node by performing a ritual with an elemental weapon. The type of orb created depends on the node used. For example, an air node creates a devastation orb of air. The ritual takes 1 hour to complete and requires 2,000 gp worth of special components, which are consumed.",
-				"A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as <a href=\"spells.html#identify_phb\" target=\"_blank\">identify</a> and <a href=\"spells.html#divination_phb\" target=\"_blank\">divination</a> can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.",
+				"A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as {@spell identify|phb} and {@spell divination|phb} can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.",
 				"A special container can be crafted to contain a devastation orb and prevent it from detonating. The container must be inscribed with symbols of the orb's opposing element. For example, a case inscribed with earth symbols can be used to contain a devastation orb of air and keep it from detonating. While in the container, the orb thrums. If it is removed from the container after the time when it was supposed to detonate, it explodes 1d6 rounds later, unless it is returned to the container.",
 				"Regardless of the type of orb, its effect is contained within a sphere with a 1 mile radius. The orb is the sphere's point of origin. The orb is destroyed after one use.",
 				"Water Orb. When this orb detonates, it creates a torrential rainstorm that lasts for 24 hours. Within the area of effect, the rules for heavy precipitation apply, as detailed in chapter 5 of the Dungeon Master's Guide. If there is a substantial body of water in the area, it floods after 2d10 hours of heavy rain, rising 10 feet above its banks and inundating the surrounding area. The flood advances at a rate of 100 feet per round, moving away from the body of water where it began until it reaches the edge of the area of effect: at that point, the water flows downhill (and possibly recedes back to its origin). Light structures collapse and wash away. Any Large or smaller creature caught in the flood's path is swept away. The flooding destroys crops and might trigger mudslides, depending on the terrain."
@@ -3786,7 +3688,7 @@
 			"source": "DMG",
 			"page": "166",
 			"entries": [
-				"This small sphere of thick glass weighs 1 pound. If you are within 60 feet of it, you can speak its command word and cause it to emanate the <a href=\"spells.html#light_phb\" target=\"_blank\">light</a> or <a href=\"spells.html#daylight_phb\" target=\"_blank\">daylight</a> spell. Once used, the <a href=\"spells.html#daylight_phb\" target=\"_blank\">daylight</a> effect can't be used again until the next dawn.",
+				"This small sphere of thick glass weighs 1 pound. If you are within 60 feet of it, you can speak its command word and cause it to emanate the {@spell light|phb} or {@spell daylight|phb} spell. Once used, the {@spell daylight|phb} effect can't be used again until the next dawn.",
 				"You can speak another command word as an action to make the illuminated globe rise into the air and float no more than 5 feet off the ground. The globe hovers in this way until you or another creature grasps it. If you move more than 60 feet from the hovering globe, it follows you until it is within 60 feet of you. It takes the shortest route to do so. If prevented from moving, the globe sinks gently to the ground and becomes inactive, and its light winks out."
 			]
 		},
@@ -3798,7 +3700,7 @@
 			"source": "DMG",
 			"page": "258",
 			"entries": [
-				"This poison is typically made only by the draw, and only in a place far removed from sunlight. A creature subjected to this poison must succeed on a DC 13 Constitution saving throw or be poisoned for 1 hour. If the saving throw fails by 5 or more, the creature is also unconscious while poisoned in this way. The creature wakes up if it takes damage or if another creature takes an action to shake it awake."
+				"This poison is typically made only by the drow, and only in a place far removed from sunlight. A creature subjected to this poison must succeed on a DC 13 Constitution saving throw or be poisoned for 1 hour. If the saving throw fails by 5 or more, the creature is also unconscious while poisoned in this way. The creature wakes up if it takes damage or if another creature takes an action to shake it awake."
 			]
 		},
 		{
@@ -3898,7 +3800,7 @@
 			"page": "166",
 			"entries": [
 				"Found in a small container, this powder resembles very fine sand. It appears to be dust of disappearance, and an identify spell reveals it to be such. There is enough of it for one use.",
-				"When you use an action to throw a handful of the dust into the air, you and each creature that needs to breathe within 30 feet of you must succeed on a DC 15 Constitution saving throw or become unable to breathe while sneezing uncontrollably. A creature affected in this way is incapacitated and suffocating. As long as it is conscious, a creature can repeat the saving throw at the end of each of its turns, ending the effect on it on a success. The <a href=\"spells.html#lesser%20restoration_phb\" target=\"_blank\">lesser restoration</a> spell can also end the effect on a creature."
+				"When you use an action to throw a handful of the dust into the air, you and each creature that needs to breathe within 30 feet of you must succeed on a DC 15 Constitution saving throw or become unable to breathe while sneezing uncontrollably. A creature affected in this way is incapacitated and suffocating. As long as it is conscious, a creature can repeat the saving throw at the end of each of its turns, ending the effect on it on a success. The {@spell lesser restoration|phb} spell can also end the effect on a creature."
 			]
 		},
 		{
@@ -4168,7 +4070,7 @@
 				"Properties of the Eye. Your alignment changes to neutral evil, and you gain the following benefits:",
 				"• You have truesight.",
 				"• You can use an action to see as if you were wearing a ring of X-ray vision. You can end this effect as a bonus action.",
-				"• The eye has 8 charges. You can use an action and expend 1 or more charges to cast one of the following spells (save DC 18) from it: <a href=\"spells.html#clairvoyance_phb\" target=\"_blank\">clairvoyance</a> (2 charges), <a href=\"spells.html#crown%20of%20madness_phb\" target=\"_blank\">crown of madness</a> (1 charge), <a href=\"spells.html#disintegrate_phb\" target=\"_blank\">disintegrate</a> (4 charges), {@spell dominate monster|phb} (5 charges), or <a href=\"spells.html#eyebite_phb\" target=\"_blank\">eyebite</a> (4 charges). The eye regains 1d4+4 expended charges daily at dawn. Each time you cast a spell from the eye, there is a 5 percent chance that Vecna tears your soul from your body, devours it, and then takes control of the body like a puppet. If that happens, you become an NPC under the DM's control.",
+				"• The eye has 8 charges. You can use an action and expend 1 or more charges to cast one of the following spells (save DC 18) from it: {@spell clairvoyance|phb} (2 charges), {@spell crown of madness|phb} (1 charge), {@spell disintegrate|phb} (4 charges), {@spell dominate monster|phb} (5 charges), or {@spell eyebite|phb} (4 charges). The eye regains 1d4+4 expended charges daily at dawn. Each time you cast a spell from the eye, there is a 5 percent chance that Vecna tears your soul from your body, devours it, and then takes control of the body like a puppet. If that happens, you become an NPC under the DM's control.",
 				"Properties of the Eye and Hand. If you are attuned to both the hand and eye, you gain the following additional benefits:",
 				"• You are immune to disease and poison.",
 				"• Using the eye's X-ray vision never causes you to suffer exhaustion.",
@@ -4188,7 +4090,7 @@
 			"page": "168",
 			"reqAttune": "YES",
 			"entries": [
-				"These crystal lenses fit over the eyes. They have 3 charges. While wearing them, you can expend 1 charge as an action to cast the <a href=\"spells.html#charm%20person_phb\" target=\"_blank\">charm person</a> spell (save DC 13) on a humanoid within 30 feet of you, provided that you and the target can see each other. The lenses regain all expended charges daily at dawn."
+				"These crystal lenses fit over the eyes. They have 3 charges. While wearing them, you can expend 1 charge as an action to cast the {@spell charm person|phb} spell (save DC 13) on a humanoid within 30 feet of you, provided that you and the target can see each other. The lenses regain all expended charges daily at dawn."
 			]
 		},
 		{
@@ -4743,7 +4645,7 @@
 				"Properties of the Hand. Your alignment changes neutral evil, and you gain the following benefits:",
 				"• Your Strength score becomes 20, unless it is already 20 or higher.",
 				"• Any melee spell attack you make with the hand, and any melee weapon attack made with a weapon held by it, deals an extra 2d8 cold damage on a hit.",
-				"• The hand has 8 charges. You can use an action and expend 1 or more charges to cast one of the following spells (save DC 18) from it: <a href=\"spells.html#finger%20of%20death_phb\" target=\"_blank\">finger of death</a> (5 charges), <a href=\"spells.html#sleep_phb\" target=\"_blank\">sleep</a> (1 charge), <a href=\"spells.html#slow_phb\" target=\"_blank\">slow</a> (2 charges), or {@spell teleport|phb} (3 charges). The hand regains 1d4+4 expended charges daily at dawn. Each time you cast a spell from the hand, it casts the <a href=\"spells.html#suggestion_phb\" target=\"_blank\">suggestion</a> spell on you (save DC 18), demanding that you commit an evil act. The hand might have a specific act in mind or leave it up to you.",
+				"• The hand has 8 charges. You can use an action and expend 1 or more charges to cast one of the following spells (save DC 18) from it: <a href=\"spells.html#finger%20of%20death_phb\" target=\"_blank\">finger of death</a> (5 charges), <a href=\"spells.html#sleep_phb\" target=\"_blank\">sleep</a> (1 charge), <a href=\"spells.html#slow_phb\" target=\"_blank\">slow</a> (2 charges), or {@spell teleport|phb} (3 charges). The hand regains 1d4+4 expended charges daily at dawn. Each time you cast a spell from the hand, it casts the {@spell suggestion|phb} spell on you (save DC 18), demanding that you commit an evil act. The hand might have a specific act in mind or leave it up to you.",
 				"Properties of the Eye and Hand. If you are attuned to both the hand and eye, you gain the following additional benefits:",
 				"• You are immune to disease and poison.",
 				"• Using the eye's X-ray vision never causes you to suffer exhaustion.",
@@ -4781,7 +4683,7 @@
 			"entries": [
 				"A sentient (neutral evil) greatsword, Hazirawn is capable of speech in Common and Netherese. Even if you aren't attuned to the sword, you gain a +1 bonus on attack and damage rolls made with this weapon. If you are attuned to Hazirawn, you deal an extra 1d6 necrotic damage when you hit with the weapon.",
 				"Increased Potency. While you are attuned to this weapon, its bonus on attack and damage rolls increases to +2, and a hit deals an extra 2d6 necrotic damage (instead of 1d6)",
-				"Spells. Hazirawn has 4 charges to cast spells. As long as the sword is attuned to you and you are holding it in your hand, you can cast <a href=\"spells.html#detect%20magic_phb\" target=\"_blank\">detect magic</a> (1 charge), {@spell detect evil and good|phb} (1 charge), or <a href=\"spells.html#detect%20thoughts_phb\" target=\"_blank\">detect thoughts</a> (2 charges). Each night at midnight, Hazirawn regains 1d4 expended charges.",
+				"Spells. Hazirawn has 4 charges to cast spells. As long as the sword is attuned to you and you are holding it in your hand, you can cast {@spell detect magic|phb} (1 charge), {@spell detect evil and good|phb} (1 charge), or {@spell detect thoughts|phb} (2 charges). Each night at midnight, Hazirawn regains 1d4 expended charges.",
 				"Wounding. While you are attuned to the weapon, any creature that you hit with Hazirawn can't regain hit points for 1 minute. The target can make a DC 15 Constitution saving throw at the end of each of its turns, ending this effect early on a success."
 			]
 		},
@@ -4820,7 +4722,7 @@
 			"entries": [
 				"This dazzling helm is set with 1d10 diamonds, 2d10 rubies, 3d10 fire opals, and 4d10 opals. Any gem pried from the helm crumbles to dust. When all the gems are removed or destroyed, the helm loses its magic.",
 				"You gain the following benefits while wearing it:",
-				"• You can use an action to cast one of the following spells (save DC 18), using one of the helm's gems of the specified type as a component: <a href=\"spells.html#daylight_phb\" target=\"_blank\">daylight</a> (opal), <a href=\"spells.html#fireball_phb\" target=\"_blank\">fireball</a> (fire opal), <a href=\"spells.html#prismatic%20spray_phb\" target=\"_blank\">prismatic spray</a> (diamond), or <a href=\"spells.html#wall%20of%20fire_phb\" target=\"_blank\">wall of fire</a> (ruby). The gem is destroyed when the spell is cast and disappears from the helm.",
+				"• You can use an action to cast one of the following spells (save DC 18), using one of the helm's gems of the specified type as a component: {@spell daylight|phb} (opal), <a href=\"spells.html#fireball_phb\" target=\"_blank\">fireball</a> (fire opal), {@spell prismatic spray|phb} (diamond), or {@spell wall of fire|phb} (ruby). The gem is destroyed when the spell is cast and disappears from the helm.",
 				"• As long as it has at least one diamond, the helm emits dim light in a 30-foot radius when at least one undead is within that area. Any undead that starts its turn in that area takes 1d6 radiant damage.",
 				"• As long as the helm has at least one ruby, you have resistance to fire damage.",
 				"• As long as the helm has at least one fire opal, you can use an action and speak a command word to cause one weapon you are holding to burst into flames. The flames emit bright light in a 10-foot radius and dim light for an additional 10 feet. The flames are harmless to you and the weapon. When you hit with an attack using the blazing weapon, the target takes an extra 1d6 fire damage. The flames last until you use a bonus action to speak the command word again or until you drop or stow the weapon.",
@@ -4847,8 +4749,8 @@
 			"page": "174",
 			"reqAttune": "YES",
 			"entries": [
-				"While wearing this helm, you can use an action to cast the <a href=\"spells.html#detect%20thoughts_phb\" target=\"_blank\">detect thoughts</a> spell (save DC 13) from it. As long as you maintain concentration on the spell, you can use a bonus action to send a telepathic message to a creature you are focused on. It can reply  \u2014  using a bonus action to do so  \u2014  while your focus on it continues.",
-				"While focusing on a creature with <a href=\"spells.html#detect%20thoughts_phb\" target=\"_blank\">detect thoughts</a>, you can use an action to cast the <a href=\"spells.html#suggestion_phb\" target=\"_blank\">suggestion</a> spell (save DC 13) from the helm on that creature. Once used, the suggestion property can't be used again until the next dawn."
+				"While wearing this helm, you can use an action to cast the {@spell detect thoughts|phb} spell (save DC 13) from it. As long as you maintain concentration on the spell, you can use a bonus action to send a telepathic message to a creature you are focused on. It can reply  \u2014  using a bonus action to do so  \u2014  while your focus on it continues.",
+				"While focusing on a creature with {@spell detect thoughts|phb}, you can use an action to cast the {@spell suggestion|phb} spell (save DC 13) from the helm on that creature. Once used, the suggestion property can't be used again until the next dawn."
 			]
 		},
 		{
@@ -5183,7 +5085,7 @@
 				"You can use an action to play the instrument and cast one of its spells. Once the instrument has been used to cast a spell, it can't be used to cast that spell again until the next dawn. The spells use your spellcasting ability and spell save DC.",
 				"When you use the instrument to cast a spell that causes targets to become charmed on a failed save, the targets have disadvantage on the saving throw. This effect applies whether you are using the instrument as the source of the spell or as a spellcasting focus.",
 				"All instruments of the bards can be used to cast the following spells: <a href=\"spells.html#fly\" target=\"_blank\">fly</a>, <a href=\"spells.html#invisibility\" target=\"_blank\">invisibility</a>, <a href=\"spells.html#levitate\" target=\"_blank\">levitate</a>, and <a href=\"spells.html#protection%20from%20evil%20and%20good\" target=\"_blank\">protection from evil and good</a>.",
-				"In addition, the Anstruth harp can be used to cast <a href=\"spells.html#control%20weather_phb\" target=\"_blank\">control weather</a>, <a href=\"spells.html#cure%20wounds_phb\" target=\"_blank\">cure wounds</a> (5th level), and <a href=\"spells.html#wall%20of%20thorns_phb\" target=\"_blank\">wall of thorns</a>."
+				"In addition, the Anstruth harp can be used to cast <a href=\"spells.html#control%20weather_phb\" target=\"_blank\">control weather</a>, {@spell cure wounds|phb} (5th level), and <a href=\"spells.html#wall%20of%20thorns_phb\" target=\"_blank\">wall of thorns</a>."
 			]
 		},
 		{
@@ -5201,7 +5103,7 @@
 				"You can use an action to play the instrument and cast one of its spells. Once the instrument has been used to cast a spell, it can't be used to cast that spell again until the next dawn. The spells use your spellcasting ability and spell save DC.",
 				"When you use the instrument to cast a spell that causes targets to become charmed on a failed save, the targets have disadvantage on the saving throw. This effect applies whether you are using the instrument as the source of the spell or as a spellcasting focus.",
 				"All instruments of the bards can be used to cast the following spells: <a href=\"spells.html#fly\" target=\"_blank\">fly</a>, <a href=\"spells.html#invisibility\" target=\"_blank\">invisibility</a>, <a href=\"spells.html#levitate\" target=\"_blank\">levitate</a>, and <a href=\"spells.html#protection%20from%20evil%20and%20good\" target=\"_blank\">protection from evil and good</a>.",
-				"In addition, the Canaith mandolin can be used to cast <a href=\"spells.html#cure%20wounds_phb\" target=\"_blank\">cure wounds</a> (3rd level), <a href=\"spells.html#dispel%20magic_phb\" target=\"_blank\">dispel magic</a>, and <a href=\"spells.html#protection%20from%20energy_phb\" target=\"_blank\">protection from energy</a> (lightning only)."
+				"In addition, the Canaith mandolin can be used to cast {@spell cure wounds|phb} (3rd level), <a href=\"spells.html#dispel%20magic_phb\" target=\"_blank\">dispel magic</a>, and <a href=\"spells.html#protection%20from%20energy_phb\" target=\"_blank\">protection from energy</a> (lightning only)."
 			]
 		},
 		{
@@ -5219,7 +5121,7 @@
 				"You can use an action to play the instrument and cast one of its spells. Once the instrument has been used to cast a spell, it can't be used to cast that spell again until the next dawn. The spells use your spellcasting ability and spell save DC.",
 				"When you use the instrument to cast a spell that causes targets to become charmed on a failed save, the targets have disadvantage on the saving throw. This effect applies whether you are using the instrument as the source of the spell or as a spellcasting focus.",
 				"All instruments of the bards can be used to cast the following spells: <a href=\"spells.html#fly\" target=\"_blank\">fly</a>, <a href=\"spells.html#invisibility\" target=\"_blank\">invisibility</a>, <a href=\"spells.html#levitate\" target=\"_blank\">levitate</a>, and <a href=\"spells.html#protection%20from%20evil%20and%20good\" target=\"_blank\">protection from evil and good</a>.",
-				"In addition, the Cli lyre can be used to cast <a href=\"spells.html#stone%20shape_phb\" target=\"_blank\">stone shape</a>, <a href=\"spells.html#wall%20of%20fire_phb\" target=\"_blank\">wall of fire</a>, and <a href=\"spells.html#wind%20wall_phb\" target=\"_blank\">wind wall</a>."
+				"In addition, the Cli lyre can be used to cast <a href=\"spells.html#stone%20shape_phb\" target=\"_blank\">stone shape</a>, {@spell wall of fire|phb}, and <a href=\"spells.html#wind%20wall_phb\" target=\"_blank\">wind wall</a>."
 			]
 		},
 		{
@@ -5273,7 +5175,7 @@
 				"You can use an action to play the instrument and cast one of its spells. Once the instrument has been used to cast a spell, it can't be used to cast that spell again until the next dawn. The spells use your spellcasting ability and spell save DC.",
 				"When you use the instrument to cast a spell that causes targets to become charmed on a failed save, the targets have disadvantage on the saving throw. This effect applies whether you are using the instrument as the source of the spell or as a spellcasting focus.",
 				"All instruments of the bards can be used to cast the following spells: <a href=\"spells.html#fly\" target=\"_blank\">fly</a>, <a href=\"spells.html#invisibility\" target=\"_blank\">invisibility</a>, <a href=\"spells.html#levitate\" target=\"_blank\">levitate</a>, and <a href=\"spells.html#protection%20from%20evil%20and%20good\" target=\"_blank\">protection from evil and good</a>.",
-				"In addition, the Mac-Fuirmidh cittern can be used to cast <a href=\"spells.html#barkskin_phb\" target=\"_blank\">barkskin</a>, <a href=\"spells.html#cure%20wounds_phb\" target=\"_blank\">cure wounds</a>, and <a href=\"spells.html#fog%20cloud_phb\" target=\"_blank\">fog cloud</a>."
+				"In addition, the Mac-Fuirmidh cittern can be used to cast <a href=\"spells.html#barkskin_phb\" target=\"_blank\">barkskin</a>, {@spell cure wounds|phb}, and <a href=\"spells.html#fog%20cloud_phb\" target=\"_blank\">fog cloud</a>."
 			]
 		},
 		{
@@ -6127,7 +6029,7 @@
 			"page": "181",
 			"reqAttune": "YES",
 			"entries": [
-				"The medallion has 3 charges. While wearing it, you can use an action and expend 1 charge to cast the <a href=\"spells.html#detect%20thoughts_phb\" target=\"_blank\">detect thoughts</a> spell (save DC 13) from it. The medallion regains 1d3 expended charges daily at dawn."
+				"The medallion has 3 charges. While wearing it, you can use an action and expend 1 charge to cast the {@spell detect thoughts|phb} spell (save DC 13) from it. The medallion regains 1d3 expended charges daily at dawn."
 			]
 		},
 		{
@@ -6406,7 +6308,7 @@
 						[
 							"7-12",
 							"Curing",
-							"<a href=\"spells.html#cure%20wounds_phb\" target=\"_blank\">Cure wounds</a> (2nd level) or <a href=\"spells.html#lesser%20restoration_phb\" target=\"_blank\">lesser restoration</a>"
+							"<a href=\"spells.html#cure%20wounds_phb\" target=\"_blank\">Cure wounds</a> (2nd level) or {@spell lesser restoration|phb}"
 						],
 						[
 							"13-16",
@@ -6568,14 +6470,14 @@
 				"Each orb contains the essence of an evil dragon, a presence that resents any attempt to coax magic from it. Those lacking in force of personality might find themselves enslaved to an orb.",
 				"An orb is an etched crystal globe about 10 inches in diameter. When used, it grows to about 20 inches in diameter, and mist swirls inside it.",
 				"While attuned to an orb, you can use an action to peer into the orb's depths and speak its command word. You must then make a DC 15 Charisma check. On a successful check, you control the orb for as long as you remain attuned to it. On a failed check, you become charmed by the orb for as long as you remain attuned to it.",
-				"While you are charmed by the orb, you can't voluntarily end your attunement to it, and the orb casts <a href=\"spells.html#suggestion_phb\" target=\"_blank\">suggestion</a> on you at will (save DC 18), urging you to work toward the evil ends it desires. The dragon essence within the orb might want many things: the annihilation of a particular people, freedom from the orb, to spread suffering in the world, to advance the worship of Takhisis (Tiamat's name on Krynn), or something else the DM decides.",
+				"While you are charmed by the orb, you can't voluntarily end your attunement to it, and the orb casts {@spell suggestion|phb} on you at will (save DC 18), urging you to work toward the evil ends it desires. The dragon essence within the orb might want many things: the annihilation of a particular people, freedom from the orb, to spread suffering in the world, to advance the worship of Takhisis (Tiamat's name on Krynn), or something else the DM decides.",
 				"Random Properties. An Orb of Dragon kind has the following random properties:",
 				"• 2 minor beneficial properties",
 				"• 1 minor detrimental property",
 				"• 1 major detrimental property",
-				"Spells. The orb has 7 charges and regains 1d4+3 expended charges daily at dawn. If you control the orb, you can use an action and expend 1 or more charges to cast one of the following spells (save DC 18) from it: <a href=\"spells.html#cure%20wounds_phb\" target=\"_blank\">cure wounds</a> (5th-level version, 3 charges), <a href=\"spells.html#daylight_phb\" target=\"_blank\">daylight</a> (1 charge), <a href=\"spells.html#death%20ward_phb\" target=\"_blank\">death ward</a> (2 charges), or {@spell scrying|phb} (3 charges). You can also use an action to cast the <a href=\"spells.html#detect%20magic_phb\" target=\"_blank\">detect magic</a> spell from the orb without using any charges.",
+				"Spells. The orb has 7 charges and regains 1d4+3 expended charges daily at dawn. If you control the orb, you can use an action and expend 1 or more charges to cast one of the following spells (save DC 18) from it: {@spell cure wounds|phb} (5th-level version, 3 charges), {@spell daylight|phb} (1 charge), <a href=\"spells.html#death%20ward_phb\" target=\"_blank\">death ward</a> (2 charges), or {@spell scrying|phb} (3 charges). You can also use an action to cast the {@spell detect magic|phb} spell from the orb without using any charges.",
 				"Call Dragons. While you control the orb, you can use an action to cause the artifact to issue a telepathic call that extends in all directions for 40 miles. Evil dragons in range feel compelled to come to the orb as soon as possible by the most direct route. Dragon deities such as Tiamat are unaffected by this call. Dragons drawn to the orb might be hostile toward you for compelling them against their will. Once you have used this property, it can't be used again for 1 hour.",
-				"Destroying an Orb. An Orb of Dragonkind appears fragile but is impervious to most damage, including the attacks and breath weapons of dragons. A <a href=\"spells.html#disintegrate_phb\" target=\"_blank\">disintegrate</a> spell or one good hit from a +3 magic weapon is sufficient to destroy an orb, however."
+				"Destroying an Orb. An Orb of Dragonkind appears fragile but is impervious to most damage, including the attacks and breath weapons of dragons. A {@spell disintegrate|phb} spell or one good hit from a +3 magic weapon is sufficient to destroy an orb, however."
 			]
 		},
 		{
@@ -6934,7 +6836,7 @@
 			"source": "DMG",
 			"page": "187",
 			"entries": [
-				"When you drink this potion, you gain the effect of the <a href=\"spells.html#clairvoyance_phb\" target=\"_blank\">clairvoyance</a> spell. An eyeball bobs in this yellowish liquid but vanishes when the potion is opened."
+				"When you drink this potion, you gain the effect of the {@spell clairvoyance|phb} spell. An eyeball bobs in this yellowish liquid but vanishes when the potion is opened."
 			]
 		},
 		{
@@ -7194,7 +7096,7 @@
 			"source": "DMG",
 			"page": "188",
 			"entries": [
-				"When you drink this potion, you gain the effect of the <a href=\"spells.html#detect%20thoughts_phb\" target=\"_blank\">detect thoughts</a> spell (save DC 13). The potion's dense, purple liquid has an ovoid cloud of pink floating in it."
+				"When you drink this potion, you gain the effect of the {@spell detect thoughts|phb} spell (save DC 13). The potion's dense, purple liquid has an ovoid cloud of pink floating in it."
 			]
 		},
 		{
@@ -7675,7 +7577,7 @@
 				"You can expend 2 of the ring's charges to cast {@spell dominate monster|phb} on a <a href=\"bestiary.html#fire%20elemental_mm\" target=\"_blank\">fire elemental</a>. In addition, you have resistance to fire damage. You can also speak and understand Ignan.",
 				"If you help slay a <a href=\"bestiary.html#fire%20elemental_mm\" target=\"_blank\">fire elemental</a> while attuned to the ring, you gain access to the following additional properties:",
 				"• You are immune to fire damage.",
-				"• You can cast the following spells from the ring, expending the necessary number of charges: <a href=\"spells.html#burning%20hands_phb\" target=\"_blank\">burning hands</a> (1 charge), <a href=\"spells.html#fireball_phb\" target=\"_blank\">fireball</a> (2 charges), and <a href=\"spells.html#wall%20of%20fire_phb\" target=\"_blank\">wall of fire</a> (3 charges)."
+				"• You can cast the following spells from the ring, expending the necessary number of charges: <a href=\"spells.html#burning%20hands_phb\" target=\"_blank\">burning hands</a> (1 charge), <a href=\"spells.html#fireball_phb\" target=\"_blank\">fireball</a> (2 charges), and {@spell wall of fire|phb} (3 charges)."
 			]
 		},
 		{
@@ -7847,7 +7749,7 @@
 			"page": "192",
 			"reqAttune": "Outdoors at Night",
 			"entries": [
-				"While wearing this ring in dim light or darkness, you can cast <a href=\"spells.html#dancing%20lights_phb\" target=\"_blank\">dancing lights</a> and <a href=\"spells.html#light_phb\" target=\"_blank\">light</a> from the ring at will. Casting either spell from the ring requires an action.",
+				"While wearing this ring in dim light or darkness, you can cast <a href=\"spells.html#dancing%20lights_phb\" target=\"_blank\">dancing lights</a> and {@spell light|phb} from the ring at will. Casting either spell from the ring requires an action.",
 				"The ring has 6 charges for the following other properties. The ring regains 1d6 expended charges daily at dawn.",
 				"Faerie Fire. You can expend 1 charge as an action to cast <a href=\"spells.html#faerie%20fire_phb\" target=\"_blank\">faerie fire</a> from the ring.",
 				"Ball Lightning. You can expend 2 charges as an action to create one to four 3-foot-diameter spheres of lightning. The more spheres you create, the less powerful each sphere is individually.",
@@ -8007,7 +7909,7 @@
 				"• You have darkvision out to a range of 120 feet.",
 				"• You can see invisible creatures and objects, as well as see into the Ethereal Plane, out to a range of 120 feet.",
 				"The eyes on the robe can't be closed or averted. Although you can close or avert your own eyes, you are never considered to be doing so while wearing this robe.",
-				"A <a href=\"spells.html#light_phb\" target=\"_blank\">light</a> spell cast on the robe or a <a href=\"spells.html#daylight_phb\" target=\"_blank\">daylight</a> spell cast within 5 feet of the robe causes you to be blinded for 1 minute. At the end of each of your turns, you can make a Constitution saving throw (DC 11 for <a href=\"spells.html#light_phb\" target=\"_blank\">light</a> or DC 15 for <a href=\"spells.html#daylight_phb\" target=\"_blank\">daylight</a>), ending the blindness on a success."
+				"A {@spell light|phb} spell cast on the robe or a {@spell daylight|phb} spell cast within 5 feet of the robe causes you to be blinded for 1 minute. At the end of each of your turns, you can make a Constitution saving throw (DC 11 for {@spell light|phb} or DC 15 for {@spell daylight|phb}), ending the blindness on a success."
 			]
 		},
 		{
@@ -8227,7 +8129,7 @@
 			"entries": [
 				"This rod has a flanged head and the following properties.",
 				"Alertness. While holding the rod, you have advantage on Wisdom (Perception) checks and on rolls for initiative.",
-				"Spells. While holding the rod, you can use an action to cast one of the following spells from it: {@spell detect evil and good|phb}, <a href=\"spells.html#detect%20magic_phb\" target=\"_blank\">detect magic</a>, <a href=\"spells.html#detect%20poison%20and%20disease_phb\" target=\"_blank\">detect poison and disease</a>, or see <a href=\"spells.html#invisibility_phb\" target=\"_blank\">invisibility</a>.",
+				"Spells. While holding the rod, you can use an action to cast one of the following spells from it: {@spell detect evil and good|phb}, {@spell detect magic|phb}, <a href=\"spells.html#detect%20poison%20and%20disease_phb\" target=\"_blank\">detect poison and disease</a>, or see <a href=\"spells.html#invisibility_phb\" target=\"_blank\">invisibility</a>.",
 				"Protective Aura. As an action, you can plant the haft end of the rod in the ground, whereupon the rod's head sheds bright light in a 60-foot radius and dim light for an additional 60 feet. While in that bright light, you and any creature that is friendly to you gain a +1 bonus to AC and saving throws and can sense the location of any invisible hostile creature that is also in the bright light.",
 				"The rod's head stops glowing and the effect ends after 10 minutes, or when a creature uses an action to pull the rod from the ground. This property can't be used again until the next dawn."
 			]
@@ -9186,7 +9088,7 @@
 			"reqAttune": "YES",
 			"entries": [
 				"The top of this black, adamantine staff is shaped like a spider. The staff weighs 6 pounds. You must be attuned to the staff to gain its benefits and cast its spells. The staff can be wielded as a quarterstaff. It deals 1d6 extra poison damage on a hit when used to make a weapon attack.",
-				"The staff has 10 charges, which are used to fuel the spells within it. With the staff in hand, you can use your action to cast one of the following spells from the staff if the spell is on your class's spell list: <a href=\"spells.html#spider%20climb_phb\" target=\"_blank\">spider climb</a> (1 charge) or <a href=\"spells.html#web_phb\" target=\"_blank\">web</a> (2 charges, spell save DC 15). No components are required.",
+				"The staff has 10 charges, which are used to fuel the spells within it. With the staff in hand, you can use your action to cast one of the following spells from the staff if the spell is on your class's spell list: <a href=\"spells.html#spider%20climb_phb\" target=\"_blank\">spider climb</a> (1 charge) or {@spell web|phb} (2 charges, spell save DC 15). No components are required.",
 				"The staff regains 1d6+4 expended charges each day at dusk. If you expend the staff's last charge, roll a d20. On a 1, the staff crumbles to dust and is destroyed."
 			]
 		},
@@ -9232,7 +9134,7 @@
 			"page": "201",
 			"reqAttune": "by a Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard",
 			"entries": [
-				"While holding this staff, you can use an action to expend 1 of its 10 charges to cast <a href=\"spells.html#charm%20person_phb\" target=\"_blank\">charm person</a>, <a href=\"spells.html#command_phb\" target=\"_blank\">command</a>, or <a href=\"spells.html#comprehend%20languages_phb\" target=\"_blank\">comprehend languages</a> from it using your spell save DC. The staff can also be used as a magic quarterstaff.",
+				"While holding this staff, you can use an action to expend 1 of its 10 charges to cast {@spell charm person|phb}, <a href=\"spells.html#command_phb\" target=\"_blank\">command</a>, or <a href=\"spells.html#comprehend%20languages_phb\" target=\"_blank\">comprehend languages</a> from it using your spell save DC. The staff can also be used as a magic quarterstaff.",
 				"If you are holding the staff and fail a saving throw against an enchantment spell that targets only you, you can turn your failed save into a successful one. You can't use this property of the staff again until the next dawn. If you succeed on a save against an enchantment spell that targets only you, with or without the staff's intervention, you can use your reaction to expend 1 charge from the staff and turn the spell back on its caster as if you had cast the spell.",
 				"The staff regains 1d8+2 expended charges daily at dawn. If you expend the last charge, roll a d20. On a 1, the staff becomes a nonmagical quarterstaff."
 			]
@@ -9292,7 +9194,7 @@
 			"page": "202",
 			"reqAttune": "by a Bard, Cleric, or Druid",
 			"entries": [
-				" This staff has 10 charges. While holding it, you can use an action to expend 1 or more of its charges to cast one of the following spells from it, using your spell save DC and spellcasting ability modifier: <a href=\"spells.html#cure%20wounds_phb\" target=\"_blank\">cure wounds</a> (1 charge per spell level, up to 4th), <a href=\"spells.html#lesser%20restoration_phb\" target=\"_blank\">lesser restoration</a> (2 charges). or <a href=\"spells.html#mass%20cure%20wounds_phb\" target=\"_blank\">mass cure wounds</a> (5 charges).",
+				" This staff has 10 charges. While holding it, you can use an action to expend 1 or more of its charges to cast one of the following spells from it, using your spell save DC and spellcasting ability modifier: {@spell cure wounds|phb} (1 charge per spell level, up to 4th), {@spell lesser restoration|phb} (2 charges). or <a href=\"spells.html#mass%20cure%20wounds_phb\" target=\"_blank\">mass cure wounds</a> (5 charges).",
 				"The staff regains 1d6+4 expended charges daily at dawn. If you expend the last charge, roll a d20. On a 1. the staff vanishes in a flash of light, lost forever."
 			]
 		},
@@ -9435,8 +9337,8 @@
 				"This staff can be wielded as a magic quarterstaff that grants a +2 bonus to attack and damage rolls made with it. While you hold it, you gain a +2 bonus to spell attack rolls.",
 				"The staff has 50 charges for the following properties. It regains 4d6+2 expended charges daily at dawn. If you expend the last charge, roll a d20. On a 20, the staff regains 1d12+1 charges.",
 				"Spell Absorption. While holding the staff, you have advantage on saving throws against spells. In addition, you can use your reaction when another creature casts a spell that targets only you. If you do, the staff absorbs the magic of the spell, canceling its effect and gaining a number of charges equal to the absorbed spell's level. However, if doing so brings the staff's total number of charges above 50, the staff explodes as if you activated its retributive strike (see below).",
-				"Spells. While holding the staff, you can use an action to expend some of its charges to cast one of the following spells from it, using your spell save DC and spellcasting ability: {@spell conjure elemental|phb} (7 charges), <a href=\"spells.html#dispel%20magic_phb\" target=\"_blank\">dispel magic</a> (3 charges), <a href=\"spells.html#fireball_phb\" target=\"_blank\">fireball</a> (7th-level version, 7 charges), <a href=\"spells.html#flaming%20sphere_phb\" target=\"_blank\">flaming sphere</a> (2 charges), <a href=\"spells.html#ice%20storm_phb\" target=\"_blank\">ice storm</a> (4 charges), <a href=\"spells.html#invisibility_phb\" target=\"_blank\">invisibility</a> (2 charges), <a href=\"spells.html#knock_phb\" target=\"_blank\">knock</a> (2 charges), <a href=\"spells.html#lightning%20bolt_phb\" target=\"_blank\">lightning bolt</a> (7th-level version, 7 charges), <a href=\"spells.html#passwall_phb\" target=\"_blank\">passwall</a> (5 charges), {@spell plane shift|phb} (7 charges), <a href=\"spells.html#telekinesis_phb\" target=\"_blank\">telekinesis</a> (5 charges), <a href=\"spells.html#wall%20of%20fire_phb\" target=\"_blank\">wall of fire</a> (4 charges), or <a href=\"spells.html#web_phb\" target=\"_blank\">web</a> (2 charges).",
-				"You can also use an action to cast one of the following spells from the staff without using any charges: <a href=\"spells.html#arcane%20lock_phb\" target=\"_blank\">arcane lock</a>, <a href=\"spells.html#detect%20magic_phb\" target=\"_blank\">detect magic</a>, <a href=\"spells.html#enlarge%2freduce_phb\" target=\"_blank\">enlarge/reduce</a>, <a href=\"spells.html#light_phb\" target=\"_blank\">light</a>, <a href=\"spells.html#mage%20hand_phb\" target=\"_blank\">mage hand</a>, or <a href=\"spells.html#protection%20from%20evil%20and%20good_phb\" target=\"_blank\">protection from evil and good</a>.",
+				"Spells. While holding the staff, you can use an action to expend some of its charges to cast one of the following spells from it, using your spell save DC and spellcasting ability: {@spell conjure elemental|phb} (7 charges), <a href=\"spells.html#dispel%20magic_phb\" target=\"_blank\">dispel magic</a> (3 charges), <a href=\"spells.html#fireball_phb\" target=\"_blank\">fireball</a> (7th-level version, 7 charges), <a href=\"spells.html#flaming%20sphere_phb\" target=\"_blank\">flaming sphere</a> (2 charges), <a href=\"spells.html#ice%20storm_phb\" target=\"_blank\">ice storm</a> (4 charges), <a href=\"spells.html#invisibility_phb\" target=\"_blank\">invisibility</a> (2 charges), {@spell knock|phb} (2 charges), <a href=\"spells.html#lightning%20bolt_phb\" target=\"_blank\">lightning bolt</a> (7th-level version, 7 charges), {@spell passwall|phb} (5 charges), {@spell plane shift|phb} (7 charges), <a href=\"spells.html#telekinesis_phb\" target=\"_blank\">telekinesis</a> (5 charges), {@spell wall of fire|phb} (4 charges), or {@spell web|phb} (2 charges).",
+				"You can also use an action to cast one of the following spells from the staff without using any charges: <a href=\"spells.html#arcane%20lock_phb\" target=\"_blank\">arcane lock</a>, {@spell detect magic|phb}, <a href=\"spells.html#enlarge%2freduce_phb\" target=\"_blank\">enlarge/reduce</a>, {@spell light|phb}, <a href=\"spells.html#mage%20hand_phb\" target=\"_blank\">mage hand</a>, or <a href=\"spells.html#protection%20from%20evil%20and%20good_phb\" target=\"_blank\">protection from evil and good</a>.",
 				"Retributive Strike. You can use an action to break the staff over your knee or against a solid surface, performing a retributive strike. The staff is destroyed and releases its remaining magic in an explosion that expands to fill a 30-foot-radius sphere centered on it.",
 				"You have a 50 percent chance to instantly travel to a random plane of existence, avoiding the explosion. If you fail to avoid the effect, you take force damage equal to 16 x the number of charges in the staff. Every other creature in the area must make a DC 17 Dexterity saving throw. On a failed save, a creature takes an amount of damage based on how far away it is from the point of origin, as shown in the following table. On a successful save, a creature takes half as much damage.",
 				{
@@ -9495,7 +9397,7 @@
 				"The staff has 10 charges for the following properties. It regains 1d6+4 expended charges daily at dawn. If you expend the last charge, roll a d20. On a 1, the staff loses its properties and becomes a nonmagical quarterstaff.",
 				"Spells. You can use an action to expend 1 or more of the staff's charges to cast one of the following spells from it, using your spell save DC: <a href=\"spells.html#animal%20friendship_phb\" target=\"_blank\">animal friendship</a> (1 charge), <a href=\"spells.html#awaken_phb\" target=\"_blank\">awaken</a> (5 charges), <a href=\"spells.html#barkskin_phb\" target=\"_blank\">barkskin</a> (2 charges), <a href=\"spells.html#locate%20animals%20or%20plants_phb\" target=\"_blank\">locate animals or plants</a> (2 charges), <a href=\"spells.html#speak%20with%20animals_phb\" target=\"_blank\">speak with animals</a> (1 charge), <a href=\"spells.html#speak%20with%20plants_phb\" target=\"_blank\">speak with plants</a> (3 charges), or <a href=\"spells.html#wall%20of%20thorns_phb\" target=\"_blank\">wall of thorns</a> (6 charges).",
 				"You can also use an action to cast the <a href=\"spells.html#pass%20without%20trace_phb\" target=\"_blank\">pass without trace</a> spell from the staff without using any charges.",
-				"Tree Form. You can use an action to plant one end of the staff in fertile earth and expend 1 charge to transform the staff into a healthy tree. The tree is 60 feet tall and has a 5-foot-diameter trunk, and its branches at the top spread out in a 20-foot radius. The tree appears ordinary but radiates a faint aura of transmutation magic if targeted by <a href=\"spells.html#detect%20magic_phb\" target=\"_blank\">detect magic</a>. While touching the tree and using another action to speak its command, word, you return the staff to its normal form. Any creature in the tree falls when it reverts to a staff."
+				"Tree Form. You can use an action to plant one end of the staff in fertile earth and expend 1 charge to transform the staff into a healthy tree. The tree is 60 feet tall and has a 5-foot-diameter trunk, and its branches at the top spread out in a 20-foot radius. The tree appears ordinary but radiates a faint aura of transmutation magic if targeted by {@spell detect magic|phb}. While touching the tree and using another action to speak its command, word, you return the staff to its normal form. Any creature in the tree falls when it reverts to a staff."
 			]
 		},
 		{
@@ -11115,7 +11017,7 @@
 			"source": "DMG",
 			"page": "211",
 			"entries": [
-				" This wand has 3 charges. While holding it, you can expend 1 charge as an action to cast the <a href=\"spells.html#detect%20magic_phb\" target=\"_blank\">detect magic</a> spell from it. The wand regains 1d3 expended charges daily at dawn."
+				" This wand has 3 charges. While holding it, you can expend 1 charge as an action to cast the {@spell detect magic|phb} spell from it. The wand regains 1d3 expended charges daily at dawn."
 			]
 		},
 		{
@@ -11211,7 +11113,7 @@
 			"page": "211",
 			"reqAttune": "by a Spellcaster",
 			"entries": [
-				" This wand has 7 charges. While holding it, you can use an action to expend 1 of its charges to cast the <a href=\"spells.html#polymorph_phb\" target=\"_blank\">polymorph</a> spell (save DC 15) from it.",
+				" This wand has 7 charges. While holding it, you can use an action to expend 1 of its charges to cast the {@spell polymorph|phb} spell (save DC 15) from it.",
 				"The wand regains 1d6+1 expended charges daily at dawn. If you expend the wand's last charge, roll a d20. On a 1, the wand crumbles into ashes and is destroyed."
 			]
 		},
@@ -11251,7 +11153,7 @@
 			"page": "212",
 			"reqAttune": "by a Spellcaster",
 			"entries": [
-				" This wand has 7 charges. While holding it, you can use an action to expend 1 of its charges to cast the <a href=\"spells.html#web_phb\" target=\"_blank\">web</a> spell (save DC 15) from it.",
+				" This wand has 7 charges. While holding it, you can use an action to expend 1 of its charges to cast the {@spell web|phb} spell (save DC 15) from it.",
 				"The wand regains 1d6+1 expended charges daily at dawn. If you expend the wand's last charge, roll a d20. On a 1, the wand crumbles into ashes and is destroyed."
 			]
 		},
@@ -11310,7 +11212,7 @@
 						],
 						[
 							"21-25",
-							"You cast <a href=\"spells.html#detect%20thoughts_phb\" target=\"_blank\">detect thoughts</a> on the target you chose. If you didn't target a creature, you instead take 1d6 psychic damage.."
+							"You cast {@spell detect thoughts|phb} on the target you chose. If you didn't target a creature, you instead take 1d6 psychic damage.."
 						],
 						[
 							"26-30",
@@ -12367,7 +12269,7 @@
 			"page": "228",
 			"reqAttune": "YES",
 			"entries": [
-				"This dark cloak is made of cured hell hound hide. As an action, you can command the cloak to transform you into a hell hound for up to 1 hour. The transformation otherwise functions as the <a href=\"spells.html#polymorph_phb\" target=\"_blank\">polymorph</a> spell, but you can use a bonus action to revert to your normal form.",
+				"This dark cloak is made of cured hell hound hide. As an action, you can command the cloak to transform you into a hell hound for up to 1 hour. The transformation otherwise functions as the {@spell polymorph|phb} spell, but you can use a bonus action to revert to your normal form.",
 				"Curse. This cloak is cursed with the essence of a hell hound, and becoming attuned to it extends the curse to you. Until the curse is broken with {@spell remove curse|phb} or similar magic, you are unwilling to part with the cloak, keeping it within reach at all times.",
 				"The sixth time you use the cloak, and each time thereafter, you must make a DC 15 Charisma saving throw. On a failed save, the transformation lasts until dispelled or until you drop to 0 hit points, and you can't willingly return to normal form. If you ever remain in hell hound form for 6 hours, the transformation becomes permanent and you lose your sense of self. All your statistics are then replaced by those of a hell hound. Thereafter, only {@spell remove curse|phb} or similar magic allows you to regain your identity and return to normal. If you remain in this permanent form for 6 days, only a {@spell wish|phb} spell can reverse the transformation."
 			]
@@ -12381,7 +12283,7 @@
 			"page": "228",
 			"entries": [
 				"This stone is a large gem worth 150 gp.",
-				"Curse. The stone is cursed, but its magical nature is hidden; <a href=\"spells.html#detect%20magic_phb\" target=\"_blank\">detect magic</a> doesn't detect it. An identify spell reveals the stone's true nature. If you use the Dash or Disengage action while the stone is on your person, its curse activates. Until the curse is broken with {@spell remove curse|phb} or similar magic, your speed is reduced by 5 feet, and your maximum load and maximum lift capacities are halved. You also become unwilling to part with the stone."
+				"Curse. The stone is cursed, but its magical nature is hidden; {@spell detect magic|phb} doesn't detect it. An identify spell reveals the stone's true nature. If you use the Dash or Disengage action while the stone is on your person, its curse activates. Until the curse is broken with {@spell remove curse|phb} or similar magic, your speed is reduced by 5 feet, and your maximum load and maximum lift capacities are halved. You also become unwilling to part with the stone."
 			]
 		},
 		{
@@ -12648,7 +12550,7 @@
 						],
 						[
 							"71-95",
-							"You are paralyzed for 1 minute or until this effect is ended with a <a href=\"spells.html#lesser%20restoration_phb\" target=\"_blank\">lesser restoration</a> spell or similar magic."
+							"You are paralyzed for 1 minute or until this effect is ended with a {@spell lesser restoration|phb} spell or similar magic."
 						],
 						[
 							"96-00",

--- a/data/loot.json
+++ b/data/loot.json
@@ -1,127 +1,177 @@
-var lootdata =
 {
 	"individual": [
 		{
 			"name": "Challenge 0-4",
-			"mincr": "0",
-			"maxcr": "4",
+			"mincr": 0,
+			"maxcr": 4,
 			"table": [
 				{
-					"min": "1",
-					"max": "30",
-					"cp": "5d6"
+					"min": 1,
+					"max": 30,
+					"coins":
+					{
+						"cp": "5d6"
+					}
 				},
 				{
-					"min": "31",
-					"max": "60",
-					"sp": "4d6"
+					"min": 31,
+					"max": 60,
+					"coins":
+					{
+						"sp": "4d6"
+					}
 				},
 				{
-					"min": "61",
-					"max": "70",
-					"ep": "3d6"
+					"min": 61,
+					"max": 70,
+					"coins":
+					{
+						"ep": "3d6"
+					}
 				},
 				{
-					"min": "71",
-					"max": "95",
-					"gp": "3d6"
+					"min": 71,
+					"max": 95,
+					"coins":
+					{
+						"gp": "3d6"
+					}
 				},
 				{
-					"min": "96",
-					"max": "100",
-					"pp": "1d6"
+					"min": 96,
+					"max": 100,
+					"coins":
+					{
+						"pp": "1d6"
+					}
 				}
 			]
 		},
 		{
 			"name": "Challenge 5-10",
-			"mincr": "5",
-			"maxcr": "10",
+			"mincr": 5,
+			"maxcr": 10,
 			"table": [
 				{
-					"min": "1",
-					"max": "30",
-					"cp": "4d6*100",
-					"ep": "1d6*10"
+					"min": 1,
+					"max": 30,
+					"coins":
+					{
+						"cp": "4d6*100",
+						"ep": "1d6*10"
+					}
 				},
 				{
-					"min": "31",
-					"max": "60",
-					"sp": "6d6*10",
-					"gp": "2d6*10"
+					"min": 31,
+					"max": 60,
+					"coins":
+					{
+						"sp": "6d6*10",
+						"gp": "2d6*10"
+					}
 				},
 				{
-					"min": "61",
-					"max": "70",
-					"ep": "3d6*10",
-					"gp": "2d6*10"
+					"min": 61,
+					"max": 70,
+					"coins":
+					{
+						"ep": "3d6*10",
+						"gp": "2d6*10"
+					}
 				},
 				{
-					"min": "71",
-					"max": "95",
-					"gp": "4d6*10"
+					"min": 71,
+					"max": 95,
+					"coins":
+					{
+						"gp": "4d6*10"
+					}
 				},
 				{
-					"min": "96",
-					"max": "100",
-					"gp": "2d6*10",
-					"pp": "3d6"
+					"min": 96,
+					"max": 100,
+					"coins":
+					{
+						"gp": "2d6*10",
+						"pp": "3d6"
+					}
 				}
 			]
 		},
 		{
 			"name": "Challenge 11-16",
-			"mincr": "11",
-			"maxcr": "16",
+			"mincr": 11,
+			"maxcr": 16,
 			"table": [
 				{
-					"min": "1",
-					"max": "20",
-					"sp": "4d6*100",
-					"gp": "1d6*100"
+					"min": 1,
+					"max": 20,
+					"coins":
+					{
+						"sp": "4d6*100",
+						"gp": "1d6*100"
+					}
 				},
 				{
-					"min": "21",
-					"max": "35",
-					"ep": "1d6*100",
-					"gp": "1d6*100"
+					"min": 21,
+					"max": 35,
+					"coins":
+					{
+						"ep": "1d6*100",
+						"gp": "1d6*100"
+					}
 				},
 				{
-					"min": "36",
-					"max": "75",
-					"gp": "2d6*100",
-					"pp": "1d6*10"
+					"min": 36,
+					"max": 75,
+					"coins":
+					{
+						"gp": "2d6*100",
+						"pp": "1d6*10"
+					}
 				},
 				{
-					"min": "76",
-					"max": "100",
-					"gp": "2d6*100",
-					"pp": "2d6*10"
+					"min": 76,
+					"max": 100,
+					"coins":
+					{
+						"gp": "2d6*100",
+						"pp": "2d6*10"
+					}
 				}
 			]
 		},
 		{
 			"name": "Challenge 17+",
-			"mincr": "17",
-			"maxcr": "30",
+			"mincr": 17,
+			"maxcr": 30,
 			"table": [
 				{
-					"min": "1",
-					"max": "15",
-					"ep": "2d6*1000",
-					"pp": "8d6*100"
+					"min": 1,
+					"max": 15,
+					"coins":
+					{
+						"ep": "2d6*1000",
+						"pp": "8d6*100"
+					}
 				},
 				{
-					"min": "16",
-					"max": "55",
-					"gp": "1d6*1000",
-					"pp": "1d6*100"
+					"min": 16,
+					"max": 55,
+					"coins":
+					{
+						"gp": "1d6*1000",
+						"pp": "1d6*100"
+					}
 				},
 				{
-					"min": "56",
-					"max": "100",
-					"gp": "1d6*1000",
-					"pp": "2d6*100"
+					"min": 56,
+					"max": 100,
+					"coins":
+					{
+						"gp": "1d6*1000",
+						"pp": "2d6*100"
+					}
 				}
 			]
 		}
@@ -129,8 +179,8 @@ var lootdata =
 	"hoard": [
 		{
 			"name": "Challenge 0-4",
-			"mincr": "0",
-			"maxcr": "4",
+			"mincr": 0,
+			"maxcr": 4,
 			"coins":
 			{
 				"cp": "6d6*100",
@@ -139,12 +189,12 @@ var lootdata =
 			},
 			"table": [
 				{
-					"min": "1",
-					"max": "6"
+					"min": 1,
+					"max": 6
 				},
 				{
-					"min": "7",
-					"max": "16",
+					"min": 7,
+					"max": 16,
 					"gems":
 					{
 						"type": "10",
@@ -152,8 +202,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "17",
-					"max": "26",
+					"min": 17,
+					"max": 26,
 					"artobjects":
 					{
 						"type": "25",
@@ -161,8 +211,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "27",
-					"max": "36",
+					"min": 27,
+					"max": 36,
 					"gems":
 					{
 						"type": "50",
@@ -170,8 +220,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "37",
-					"max": "44",
+					"min": 37,
+					"max": 44,
 					"gems":
 					{
 						"type": "10",
@@ -184,8 +234,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "45",
-					"max": "52",
+					"min": 45,
+					"max": 52,
 					"artobjects":
 					{
 						"type": "25",
@@ -198,8 +248,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "53",
-					"max": "60",
+					"min": 53,
+					"max": 60,
 					"gems":
 					{
 						"type": "50",
@@ -212,8 +262,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "61",
-					"max": "65",
+					"min": 61,
+					"max": 65,
 					"gems":
 					{
 						"type": "10",
@@ -226,8 +276,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "66",
-					"max": "70",
+					"min": 66,
+					"max": 70,
 					"artobjects":
 					{
 						"type": "25",
@@ -240,8 +290,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "71",
-					"max": "75",
+					"min": 71,
+					"max": 75,
 					"gems":
 					{
 						"type": "50",
@@ -254,8 +304,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "76",
-					"max": "78",
+					"min": 76,
+					"max": 78,
 					"gems":
 					{
 						"type": "10",
@@ -268,8 +318,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "79",
-					"max": "80",
+					"min": 79,
+					"max": 80,
 					"artobjects":
 					{
 						"type": "25",
@@ -282,8 +332,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "81",
-					"max": "85",
+					"min": 81,
+					"max": 85,
 					"gems":
 					{
 						"type": "50",
@@ -296,8 +346,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "86",
-					"max": "92",
+					"min": 86,
+					"max": 92,
 					"artobjects":
 					{
 						"type": "25",
@@ -310,8 +360,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "93",
-					"max": "97",
+					"min": 93,
+					"max": 97,
 					"gems":
 					{
 						"type": "50",
@@ -324,8 +374,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "98",
-					"max": "99",
+					"min": 98,
+					"max": 99,
 					"artobjects":
 					{
 						"type": "25",
@@ -338,8 +388,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "100",
-					"max": "100",
+					"min": 100,
+					"max": 100,
 					"gems":
 					{
 						"type": "50",
@@ -356,8 +406,8 @@ var lootdata =
 		},
 		{
 			"name": "Challenge 5-10",
-			"mincr": "5",
-			"maxcr": "10",
+			"mincr": 5,
+			"maxcr": 10,
 			"coins":
 			{
 				"cp": "2d6*100",
@@ -367,12 +417,12 @@ var lootdata =
 			},
 			"table": [
 				{
-					"min": "1",
-					"max": "4"
+					"min": 1,
+					"max": 4
 				},
 				{
-					"min": "5",
-					"max": "10",
+					"min": 5,
+					"max": 10,
 					"artobjects":
 					{
 						"type": "25",
@@ -380,8 +430,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "11",
-					"max": "16",
+					"min": 11,
+					"max": 16,
 					"gems":
 					{
 						"type": "50",
@@ -389,8 +439,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "17",
-					"max": "22",
+					"min": 17,
+					"max": 22,
 					"gems":
 					{
 						"type": "100",
@@ -398,8 +448,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "23",
-					"max": "28",
+					"min": 23,
+					"max": 28,
 					"artobjects":
 					{
 						"type": "250",
@@ -407,8 +457,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "29",
-					"max": "32",
+					"min": 29,
+					"max": 32,
 					"artobjects":
 					{
 						"type": "25",
@@ -421,8 +471,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "33",
-					"max": "36",
+					"min": 33,
+					"max": 36,
 					"gems":
 					{
 						"type": "50",
@@ -435,8 +485,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "37",
-					"max": "40",
+					"min": 37,
+					"max": 40,
 					"gems":
 					{
 						"type": "100",
@@ -449,8 +499,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "41",
-					"max": "44",
+					"min": 41,
+					"max": 44,
 					"artobjects":
 					{
 						"type": "250",
@@ -463,8 +513,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "45",
-					"max": "49",
+					"min": 45,
+					"max": 49,
 					"artobjects":
 					{
 						"type": "25",
@@ -477,8 +527,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "50",
-					"max": "54",
+					"min": 50,
+					"max": 54,
 					"gems":
 					{
 						"type": "50",
@@ -491,8 +541,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "55",
-					"max": "59",
+					"min": 55,
+					"max": 59,
 					"gems":
 					{
 						"type": "100",
@@ -505,8 +555,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "60",
-					"max": "63",
+					"min": 60,
+					"max": 63,
 					"artobjects":
 					{
 						"type": "250",
@@ -519,8 +569,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "64",
-					"max": "66",
+					"min": 64,
+					"max": 66,
 					"artobjects":
 					{
 						"type": "25",
@@ -533,8 +583,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "67",
-					"max": "69",
+					"min": 67,
+					"max": 69,
 					"gems":
 					{
 						"type": "50",
@@ -547,8 +597,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "70",
-					"max": "72",
+					"min": 70,
+					"max": 72,
 					"gems":
 					{
 						"type": "100",
@@ -561,8 +611,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "73",
-					"max": "74",
+					"min": 73,
+					"max": 74,
 					"artobjects":
 					{
 						"type": "250",
@@ -575,8 +625,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "75",
-					"max": "76",
+					"min": 75,
+					"max": 76,
 					"artobjects":
 					{
 						"type": "25",
@@ -589,8 +639,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "77",
-					"max": "78",
+					"min": 77,
+					"max": 78,
 					"gems":
 					{
 						"type": "50",
@@ -603,8 +653,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "79",
-					"max": "79",
+					"min": 79,
+					"max": 79,
 					"gems":
 					{
 						"type": "100",
@@ -617,8 +667,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "80",
-					"max": "80",
+					"min": 80,
+					"max": 80,
 					"artobjects":
 					{
 						"type": "250",
@@ -631,8 +681,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "81",
-					"max": "84",
+					"min": 81,
+					"max": 84,
 					"artobjects":
 					{
 						"type": "25",
@@ -645,8 +695,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "85",
-					"max": "88",
+					"min": 85,
+					"max": 88,
 					"gems":
 					{
 						"type": "50",
@@ -659,8 +709,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "89",
-					"max": "91",
+					"min": 89,
+					"max": 91,
 					"gems":
 					{
 						"type": "100",
@@ -673,8 +723,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "92",
-					"max": "94",
+					"min": 92,
+					"max": 94,
 					"artobjects":
 					{
 						"type": "250",
@@ -687,8 +737,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "95",
-					"max": "96",
+					"min": 95,
+					"max": 96,
 					"gems":
 					{
 						"type": "100",
@@ -701,8 +751,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "97",
-					"max": "98",
+					"min": 97,
+					"max": 98,
 					"artobjects":
 					{
 						"type": "250",
@@ -715,8 +765,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "99",
-					"max": "99",
+					"min": 99,
+					"max": 99,
 					"gems":
 					{
 						"type": "100",
@@ -729,8 +779,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "100",
-					"max": "100",
+					"min": 100,
+					"max": 100,
 					"artobjects":
 					{
 						"type": "250",
@@ -746,8 +796,8 @@ var lootdata =
 		},
 		{
 			"name": "Challenge 11-16",
-			"mincr": "11",
-			"maxcr": "16",
+			"mincr": 11,
+			"maxcr": 16,
 			"coins":
 			{
 				"gp": "4d6*1000",
@@ -755,12 +805,12 @@ var lootdata =
 			},
 			"table": [
 				{
-					"min": "1",
-					"max": "3"
+					"min": 1,
+					"max": 3
 				},
 				{
-					"min": "4",
-					"max": "6",
+					"min": 4,
+					"max": 6,
 					"artobjects":
 					{
 						"type": "250",
@@ -768,8 +818,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "7",
-					"max": "9",
+					"min": 7,
+					"max": 9,
 					"artobjects":
 					{
 						"type": "750",
@@ -777,8 +827,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "10",
-					"max": "12",
+					"min": 10,
+					"max": 12,
 					"gems":
 					{
 						"type": "500",
@@ -786,8 +836,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "13",
-					"max": "15",
+					"min": 13,
+					"max": 15,
 					"gems":
 					{
 						"type": "1000",
@@ -795,8 +845,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "16",
-					"max": "19",
+					"min": 16,
+					"max": 19,
 					"artobjects":
 					{
 						"type": "250",
@@ -809,8 +859,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "20",
-					"max": "23",
+					"min": 20,
+					"max": 23,
 					"artobjects":
 					{
 						"type": "750",
@@ -823,8 +873,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "24",
-					"max": "26",
+					"min": 24,
+					"max": 26,
 					"gems":
 					{
 						"type": "500",
@@ -837,8 +887,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "27",
-					"max": "29",
+					"min": 27,
+					"max": 29,
 					"gems":
 					{
 						"type": "1000",
@@ -851,8 +901,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "30",
-					"max": "35",
+					"min": 30,
+					"max": 35,
 					"artobjects":
 					{
 						"type": "250",
@@ -865,8 +915,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "36",
-					"max": "40",
+					"min": 36,
+					"max": 40,
 					"artobjects":
 					{
 						"type": "750",
@@ -879,8 +929,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "41",
-					"max": "45",
+					"min": 41,
+					"max": 45,
 					"gems":
 					{
 						"type": "500",
@@ -893,8 +943,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "46",
-					"max": "50",
+					"min": 46,
+					"max": 50,
 					"gems":
 					{
 						"type": "1000",
@@ -907,8 +957,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "51",
-					"max": "54",
+					"min": 51,
+					"max": 54,
 					"artobjects":
 					{
 						"type": "250",
@@ -921,8 +971,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "55",
-					"max": "58",
+					"min": 55,
+					"max": 58,
 					"artobjects":
 					{
 						"type": "750",
@@ -935,8 +985,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "59",
-					"max": "62",
+					"min": 59,
+					"max": 62,
 					"gems":
 					{
 						"type": "500",
@@ -949,8 +999,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "63",
-					"max": "66",
+					"min": 63,
+					"max": 66,
 					"gems":
 					{
 						"type": "1000",
@@ -963,8 +1013,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "67",
-					"max": "68",
+					"min": 67,
+					"max": 68,
 					"artobjects":
 					{
 						"type": "250",
@@ -977,8 +1027,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "69",
-					"max": "70",
+					"min": 69,
+					"max": 70,
 					"artobjects":
 					{
 						"type": "750",
@@ -991,8 +1041,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "71",
-					"max": "72",
+					"min": 71,
+					"max": 72,
 					"gems":
 					{
 						"type": "500",
@@ -1005,8 +1055,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "73",
-					"max": "74",
+					"min": 73,
+					"max": 74,
 					"gems":
 					{
 						"type": "1000",
@@ -1019,8 +1069,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "75",
-					"max": "76",
+					"min": 75,
+					"max": 76,
 					"artobjects":
 					{
 						"type": "250",
@@ -1033,8 +1083,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "77",
-					"max": "78",
+					"min": 77,
+					"max": 78,
 					"artobjects":
 					{
 						"type": "750",
@@ -1047,8 +1097,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "79",
-					"max": "80",
+					"min": 79,
+					"max": 80,
 					"gems":
 					{
 						"type": "500",
@@ -1061,8 +1111,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "81",
-					"max": "82",
+					"min": 81,
+					"max": 82,
 					"gems":
 					{
 						"type": "1000",
@@ -1075,8 +1125,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "83",
-					"max": "85",
+					"min": 83,
+					"max": 85,
 					"artobjects":
 					{
 						"type": "250",
@@ -1089,8 +1139,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "86",
-					"max": "88",
+					"min": 86,
+					"max": 88,
 					"artobjects":
 					{
 						"type": "750",
@@ -1103,8 +1153,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "89",
-					"max": "90",
+					"min": 89,
+					"max": 90,
 					"gems":
 					{
 						"type": "500",
@@ -1117,8 +1167,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "91",
-					"max": "92",
+					"min": 91,
+					"max": 92,
 					"gems":
 					{
 						"type": "1000",
@@ -1131,8 +1181,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "93",
-					"max": "94",
+					"min": 93,
+					"max": 94,
 					"artobjects":
 					{
 						"type": "250",
@@ -1145,8 +1195,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "95",
-					"max": "96",
+					"min": 95,
+					"max": 96,
 					"artobjects":
 					{
 						"type": "750",
@@ -1159,8 +1209,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "97",
-					"max": "98",
+					"min": 97,
+					"max": 98,
 					"gems":
 					{
 						"type": "500",
@@ -1173,8 +1223,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "99",
-					"max": "100",
+					"min": 99,
+					"max": 100,
 					"gems":
 					{
 						"type": "1000",
@@ -1190,8 +1240,8 @@ var lootdata =
 		},
 		{
 			"name": "Challenge 17+",
-			"mincr": "17",
-			"maxcr": "30",
+			"mincr": 17,
+			"maxcr": 30,
 			"coins":
 			{
 				"gp": "12d6*1000",
@@ -1199,12 +1249,12 @@ var lootdata =
 			},
 			"table": [
 				{
-					"min": "1",
-					"max": "2"
+					"min": 1,
+					"max": 2
 				},
 				{
-					"min": "3",
-					"max": "5",
+					"min": 3,
+					"max": 5,
 					"gems":
 					{
 						"type": "1000",
@@ -1217,8 +1267,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "6",
-					"max": "8",
+					"min": 6,
+					"max": 8,
 					"artobjects":
 					{
 						"type": "2500",
@@ -1231,8 +1281,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "9",
-					"max": "11",
+					"min": 9,
+					"max": 11,
 					"artobjects":
 					{
 						"type": "7500",
@@ -1245,8 +1295,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "12",
-					"max": "14",
+					"min": 12,
+					"max": 14,
 					"gems":
 					{
 						"type": "5000",
@@ -1259,8 +1309,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "15",
-					"max": "22",
+					"min": 15,
+					"max": 22,
 					"gems":
 					{
 						"type": "1000",
@@ -1273,8 +1323,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "23",
-					"max": "30",
+					"min": 23,
+					"max": 30,
 					"artobjects":
 					{
 						"type": "2500",
@@ -1287,8 +1337,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "31",
-					"max": "38",
+					"min": 31,
+					"max": 38,
 					"artobjects":
 					{
 						"type": "7500",
@@ -1301,8 +1351,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "39",
-					"max": "46",
+					"min": 39,
+					"max": 46,
 					"gems":
 					{
 						"type": "5000",
@@ -1315,8 +1365,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "47",
-					"max": "52",
+					"min": 47,
+					"max": 52,
 					"gems":
 					{
 						"type": "1000",
@@ -1329,8 +1379,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "53",
-					"max": "58",
+					"min": 53,
+					"max": 58,
 					"artobjects":
 					{
 						"type": "2500",
@@ -1343,8 +1393,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "59",
-					"max": "63",
+					"min": 59,
+					"max": 63,
 					"artobjects":
 					{
 						"type": "7500",
@@ -1357,8 +1407,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "64",
-					"max": "68",
+					"min": 64,
+					"max": 68,
 					"gems":
 					{
 						"type": "5000",
@@ -1371,8 +1421,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "69",
-					"max": "69",
+					"min": 69,
+					"max": 69,
 					"gems":
 					{
 						"type": "1000",
@@ -1385,8 +1435,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "70",
-					"max": "70",
+					"min": 70,
+					"max": 70,
 					"artobjects":
 					{
 						"type": "7500",
@@ -1399,8 +1449,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "71",
-					"max": "71",
+					"min": 71,
+					"max": 71,
 					"artobjects":
 					{
 						"type": "7500",
@@ -1413,8 +1463,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "72",
-					"max": "72",
+					"min": 72,
+					"max": 72,
 					"gems":
 					{
 						"type": "5000",
@@ -1427,8 +1477,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "73",
-					"max": "74",
+					"min": 73,
+					"max": 74,
 					"gems":
 					{
 						"type": "1000",
@@ -1441,8 +1491,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "75",
-					"max": "76",
+					"min": 75,
+					"max": 76,
 					"artobjects":
 					{
 						"type": "2500",
@@ -1455,8 +1505,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "77",
-					"max": "78",
+					"min": 77,
+					"max": 78,
 					"artobjects":
 					{
 						"type": "7500",
@@ -1469,8 +1519,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "79",
-					"max": "80",
+					"min": 79,
+					"max": 80,
 					"gems":
 					{
 						"type": "5000",
@@ -1483,8 +1533,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "81",
-					"max": "85",
+					"min": 81,
+					"max": 85,
 					"gems":
 					{
 						"type": "1000",
@@ -1497,8 +1547,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "86",
-					"max": "90",
+					"min": 86,
+					"max": 90,
 					"artobjects":
 					{
 						"type": "2500",
@@ -1511,8 +1561,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "91",
-					"max": "95",
+					"min": 91,
+					"max": 95,
 					"artobjects":
 					{
 						"type": "7500",
@@ -1525,8 +1575,8 @@ var lootdata =
 					}
 				},
 				{
-					"min": "96",
-					"max": "100",
+					"min": 96,
+					"max": 100,
 					"gems":
 					{
 						"type": "1000",
@@ -1551,7 +1601,6 @@ var lootdata =
 				"Blue quartz (transparent pale blue)",
 				"Eye agate (translucent circles of gray, white brown, blue, or green)",
 				"Hematite (opaque gray-black)",
-				"Lapis lazuli (opaque light and dark blue with yellow flecks)",
 				"Lapis lazuli (opaque light and dark blue with yellow flecks)",
 				"Malachite (opaque striated light and dark green)",
 				"Moss agate (translucent pink or yellow-white with mossy gray or green markings)",
@@ -1608,7 +1657,7 @@ var lootdata =
 			]
 		},
 		{
-			"name": "1d1,000 gp Gemstones",
+			"name": "1,000 gp Gemstones",
 			"type": "1000",
 			"table": [
 				"Black opal (translucent dark green with black mottling and golden flecks)",
@@ -1690,7 +1739,7 @@ var lootdata =
 				"Old masterpiece painting",
 				"Embroidered silk and velvet mantle set with numerous moonstones",
 				"Platinum bracelet set with a sapphire",
-				"Embroidered glove set with jewel chips jeweled anklet       ",
+				"Embroidered glove set with jewel chips jeweled anklet",
 				"Gold music box",
 				"Gold circlet set with four aquamarines",
 				"Eye patch with a mock eye set in blue sapphire and moonstone",
@@ -1718,44 +1767,44 @@ var lootdata =
 			"type": "A",
 			"table": [
 				{
-					"min": "01",
-					"max": "50",
-					"item": "Potion of healing"
+					"min": 1,
+					"max": 50,
+					"item": "{@item Potion of Healing|dmg}"
 				},
 				{
-					"min": "51",
-					"max": "60",
-					"item": "Spell scroll (cantrip)"
+					"min": 51,
+					"max": 60,
+					"item": "{@item Scroll (Cantrip)|dmg}"
 				},
 				{
-					"min": "61",
-					"max": "70",
-					"item": "Potion of climbing"
+					"min": 61,
+					"max": 70,
+					"item": "{@item Potion of Climbing|dmg}"
 				},
 				{
-					"min": "71",
-					"max": "90",
-					"item": "Spell scroll (1st level)"
+					"min": 71,
+					"max": 90,
+					"item": "{@item Spell Scroll (1st Level)|dmg}"
 				},
 				{
-					"min": "91",
-					"max": "94",
-					"item": "Spell scroll (2nd level)"
+					"min": 91,
+					"max": 94,
+					"item": "{@item Spell Scroll (2nd Level)|dmg}"
 				},
 				{
-					"min": "95",
-					"max": "98",
-					"item": "Potion of greater healing"
+					"min": 95,
+					"max": 98,
+					"item": "{@item Potion of Greater Healing|dmg}"
 				},
 				{
-					"min": "99",
-					"max": "99",
-					"item": "Bag of holding"
+					"min": 99,
+					"max": 99,
+					"item": "{@item Bag of Holding|dmg}"
 				},
 				{
-					"min": "100",
-					"max": "100",
-					"item": "Driftglobe"
+					"min": 100,
+					"max": 100,
+					"item": "{@item Driftglobe|dmg}"
 				}
 			]
 		},
@@ -1764,179 +1813,179 @@ var lootdata =
 			"type": "B",
 			"table": [
 				{
-					"min": "1",
-					"max": "15",
-					"item": "Potion of greater healing"
+					"min": 1,
+					"max": 15,
+					"item": "{@item Potion of Greater Healing|dmg}"
 				},
 				{
-					"min": "16",
-					"max": "22",
-					"item": "Potion of fire breath"
+					"min": 16,
+					"max": 22,
+					"item": "{@item Potion of Fire Breath|dmg}"
 				},
 				{
-					"min": "23",
-					"max": "29",
-					"item": "Potion of resistance"
+					"min": 23,
+					"max": 29,
+					"item": "Potion of Resistance"
 				},
 				{
-					"min": "30",
-					"max": "34",
+					"min": 30,
+					"max": 34,
 					"item": "Ammunition, +1"
 				},
 				{
-					"min": "35",
-					"max": "39",
-					"item": "Potion of animal friendship"
+					"min": 35,
+					"max": 39,
+					"item": "{@item Potion of Animal Friendship|dmg}"
 				},
 				{
-					"min": "40",
-					"max": "44",
-					"item": "Potion of hill giant strength"
+					"min": 40,
+					"max": 44,
+					"item": "{@item Potion of Hill Giant Strength|dmg}"
 				},
 				{
-					"min": "45",
-					"max": "49",
-					"item": "Potion of growth"
+					"min": 45,
+					"max": 49,
+					"item": "{@item Potion of Growth|dmg}"
 				},
 				{
-					"min": "50",
-					"max": "54",
-					"item": "Potion of water breathing"
+					"min": 50,
+					"max": 54,
+					"item": "{@item Potion of Water Breathing|dmg}"
 				},
 				{
-					"min": "55",
-					"max": "59",
-					"item": "Spell scroll (2nd level)"
+					"min": 55,
+					"max": 59,
+					"item": "{@item Spell Scroll (2nd Level)|dmg}"
 				},
 				{
-					"min": "60",
-					"max": "64",
-					"item": "Spell scroll (3rd level)"
+					"min": 60,
+					"max": 64,
+					"item": "{@item Spell Scroll (3rd Level)|dmg}"
 				},
 				{
-					"min": "65",
-					"max": "67",
-					"item": "Bag of holding"
+					"min": 65,
+					"max": 67,
+					"item": "{@item Bag of Holding|dmg}"
 				},
 				{
-					"min": "68",
-					"max": "70",
-					"item": "Keoghtom's ointment"
+					"min": 68,
+					"max": 70,
+					"item": "{@item Keoghtom's Ointment|dmg}"
 				},
 				{
-					"min": "71",
-					"max": "73",
-					"item": "Oil of slipperiness"
+					"min": 71,
+					"max": 73,
+					"item": "{@item Oil of Slipperiness|dmg}"
 				},
 				{
-					"min": "74",
-					"max": "75",
-					"item": "Dust of disappearance"
+					"min": 74,
+					"max": 75,
+					"item": "{@item Dust of Disappearance|dmg}"
 				},
 				{
-					"min": "76",
-					"max": "77",
-					"item": "Dust of dryness"
+					"min": 76,
+					"max": 77,
+					"item": "{@item Dust of Dryness|dmg}"
 				},
 				{
-					"min": "78",
-					"max": "79",
-					"item": "Dust of sneezing and choking"
+					"min": 78,
+					"max": 79,
+					"item": "{@item Dust of Sneezing and Choking|dmg}"
 				},
 				{
-					"min": "80",
-					"max": "81",
-					"item": "Elemental gem"
+					"min": 80,
+					"max": 81,
+					"item": "{@item Elemental Gem|dmg}"
 				},
 				{
-					"min": "82",
-					"max": "83",
-					"item": "Philter of love"
+					"min": 82,
+					"max": 83,
+					"item": "{@item Philter of Love|dmg}"
 				},
 				{
-					"min": "84",
-					"max": "84",
-					"item": "Alchemy jug"
+					"min": 84,
+					"max": 84,
+					"item": "{@item Alchemy Jug|dmg}"
 				},
 				{
-					"min": "85",
-					"max": "85",
-					"item": "Cap of water breathing"
+					"min": 85,
+					"max": 85,
+					"item": "{@item Cap of Water Breathing|dmg}"
 				},
 				{
-					"min": "86",
-					"max": "86",
-					"item": "Cloak of the manta ray"
+					"min": 86,
+					"max": 86,
+					"item": "{@item Cloak of the Manta Ray|dmg}"
 				},
 				{
-					"min": "87",
-					"max": "87",
-					"item": "Driftglobe"
+					"min": 87,
+					"max": 87,
+					"item": "{@item Driftglobe|dmg}"
 				},
 				{
-					"min": "88",
-					"max": "88",
-					"item": "Goggles of night"
+					"min": 88,
+					"max": 88,
+					"item": "{@item Goggles of Night|dmg}"
 				},
 				{
-					"min": "89",
-					"max": "89",
-					"item": "Helm of comprehending languages"
+					"min": 89,
+					"max": 89,
+					"item": "{@item Helm of Comprehending Languages|dmg}"
 				},
 				{
-					"min": "90",
-					"max": "90",
-					"item": "Immovable rod"
+					"min": 90,
+					"max": 90,
+					"item": "{@item Immovable Rod|dmg}"
 				},
 				{
-					"min": "91",
-					"max": "91",
-					"item": "Lantern of revealing"
+					"min": 91,
+					"max": 91,
+					"item": "{@item Lantern of Revealing|dmg}"
 				},
 				{
-					"min": "92",
-					"max": "92",
-					"item": "Mariner's armor"
+					"min": 92,
+					"max": 92,
+					"item": "Mariner's Armor"
 				},
 				{
-					"min": "93",
-					"max": "93",
-					"item": "Mithral armor"
+					"min": 93,
+					"max": 93,
+					"item": "Mithral Armor"
 				},
 				{
-					"min": "94",
-					"max": "94",
-					"item": "Potion of poison"
+					"min": 94,
+					"max": 94,
+					"item": "{@item Potion of Poison|dmg}"
 				},
 				{
-					"min": "95",
-					"max": "95",
-					"item": "Ring of swimming"
+					"min": 95,
+					"max": 95,
+					"item": "{@item Ring of Swimming|dmg}"
 				},
 				{
-					"min": "96",
-					"max": "96",
-					"item": "Robe of useful items"
+					"min": 96,
+					"max": 96,
+					"item": "{@item Robe of Useful Items|dmg}"
 				},
 				{
-					"min": "97",
-					"max": "97",
-					"item": "Rope of climbing"
+					"min": 97,
+					"max": 97,
+					"item": "{@item Rope of Climbing|dmg}"
 				},
 				{
-					"min": "98",
-					"max": "98",
-					"item": "Saddle of the cavalier"
+					"min": 98,
+					"max": 98,
+					"item": "{@item Saddle of the Cavalier|dmg}"
 				},
 				{
-					"min": "99",
-					"max": "99",
-					"item": "Wand of magic detection"
+					"min": 99,
+					"max": 99,
+					"item": "{@item Wand of Magic Detection|dmg}"
 				},
 				{
-					"min": "100",
-					"max": "100",
-					"item": "Wand of secrets"
+					"min": 100,
+					"max": 100,
+					"item": "{@item Wand of Secrets|dmg}"
 				}
 			]
 		},
@@ -1945,143 +1994,143 @@ var lootdata =
 			"type": "C",
 			"table": [
 				{
-					"min": "1",
-					"max": "15",
-					"item": "Potion of superior healing"
+					"min": 1,
+					"max": 15,
+					"item": "Potion of Superior Healing"
 				},
 				{
-					"min": "16",
-					"max": "22",
-					"item": "Spell scroll (4th level)"
+					"min": 16,
+					"max": 22,
+					"item": "Spell Scroll (4th level)"
 				},
 				{
-					"min": "23",
-					"max": "27",
+					"min": 23,
+					"max": 27,
 					"item": "Ammunition, +2"
 				},
 				{
-					"min": "28",
-					"max": "32",
-					"item": "Potion of clairvoyance"
+					"min": 28,
+					"max": 32,
+					"item": "Potion of Clairvoyance"
 				},
 				{
-					"min": "33",
-					"max": "37",
-					"item": "Potion of diminution"
+					"min": 33,
+					"max": 37,
+					"item": "Potion of Diminution"
 				},
 				{
-					"min": "38",
-					"max": "42",
-					"item": "Potion of gaseous form"
+					"min": 38,
+					"max": 42,
+					"item": "Potion of Gaseous Form"
 				},
 				{
-					"min": "43",
-					"max": "47",
+					"min": 43,
+					"max": 47,
 					"item": "Potion of frost giant strength"
 				},
 				{
-					"min": "48",
-					"max": "52",
+					"min": 48,
+					"max": 52,
 					"item": "Potion of stone giant strength"
 				},
 				{
-					"min": "53",
-					"max": "57",
+					"min": 53,
+					"max": 57,
 					"item": "Potion of heroism"
 				},
 				{
-					"min": "58",
-					"max": "62",
+					"min": 58,
+					"max": 62,
 					"item": "Potion of invulnerability"
 				},
 				{
-					"min": "63",
-					"max": "67",
+					"min": 63,
+					"max": 67,
 					"item": "Potion of mind reading"
 				},
 				{
-					"min": "68",
-					"max": "72",
+					"min": 68,
+					"max": 72,
 					"item": "Spell scroll (5th level)"
 				},
 				{
-					"min": "73",
-					"max": "75",
+					"min": 73,
+					"max": 75,
 					"item": "Elixir of health"
 				},
 				{
-					"min": "76",
-					"max": "78",
+					"min": 76,
+					"max": 78,
 					"item": "Oil of etherealness"
 				},
 				{
-					"min": "79",
-					"max": "81",
+					"min": 79,
+					"max": 81,
 					"item": "Potion of fire giant strength"
 				},
 				{
-					"min": "82",
-					"max": "84",
+					"min": 82,
+					"max": 84,
 					"item": "Quaal's feather token"
 				},
 				{
-					"min": "85",
-					"max": "87",
+					"min": 85,
+					"max": 87,
 					"item": "Scroll of protection"
 				},
 				{
-					"min": "88",
-					"max": "89",
+					"min": 88,
+					"max": 89,
 					"item": "Bag of beans"
 				},
 				{
-					"min": "90",
-					"max": "91",
+					"min": 90,
+					"max": 91,
 					"item": "Bead of force"
 				},
 				{
-					"min": "92",
-					"max": "92",
+					"min": 92,
+					"max": 92,
 					"item": "Chime of opening"
 				},
 				{
-					"min": "93",
-					"max": "93",
+					"min": 93,
+					"max": 93,
 					"item": "Decanter of endless water"
 				},
 				{
-					"min": "94",
-					"max": "94",
+					"min": 94,
+					"max": 94,
 					"item": "Eyes of minute seeing"
 				},
 				{
-					"min": "95",
-					"max": "95",
+					"min": 95,
+					"max": 95,
 					"item": "Folding boat"
 				},
 				{
-					"min": "96",
-					"max": "96",
+					"min": 96,
+					"max": 96,
 					"item": "Heward's handy haversack"
 				},
 				{
-					"min": "97",
-					"max": "97",
+					"min": 97,
+					"max": 97,
 					"item": "Horseshoes of speed"
 				},
 				{
-					"min": "98",
-					"max": "98",
+					"min": 98,
+					"max": 98,
 					"item": "Necklace of fireballs"
 				},
 				{
-					"min": "99",
-					"max": "99",
+					"min": 99,
+					"max": 99,
 					"item": "Periapt of health"
 				},
 				{
-					"min": "100",
-					"max": "100",
+					"min": 100,
+					"max": 100,
 					"item": "Sending stones"
 				}
 			]
@@ -2091,83 +2140,83 @@ var lootdata =
 			"type": "D",
 			"table": [
 				{
-					"min": "1",
-					"max": "20",
+					"min": 1,
+					"max": 20,
 					"item": "Potion of supreme healing"
 				},
 				{
-					"min": "21",
-					"max": "30",
+					"min": 21,
+					"max": 30,
 					"item": "Potion of invisibility"
 				},
 				{
-					"min": "31",
-					"max": "40",
+					"min": 31,
+					"max": 40,
 					"item": "Potion of speed"
 				},
 				{
-					"min": "41",
-					"max": "50",
+					"min": 41,
+					"max": 50,
 					"item": "Spell scroll (6th level)"
 				},
 				{
-					"min": "51",
-					"max": "57",
+					"min": 51,
+					"max": 57,
 					"item": "Spell scroll (7th level)"
 				},
 				{
-					"min": "58",
-					"max": "62",
+					"min": 58,
+					"max": 62,
 					"item": "Ammunition, +3"
 				},
 				{
-					"min": "63",
-					"max": "67",
+					"min": 63,
+					"max": 67,
 					"item": "Oil of sharpness"
 				},
 				{
-					"min": "68",
-					"max": "72",
+					"min": 68,
+					"max": 72,
 					"item": "Potion of flying"
 				},
 				{
-					"min": "73",
-					"max": "77",
+					"min": 73,
+					"max": 77,
 					"item": "Potion of cloud giant strength"
 				},
 				{
-					"min": "78",
-					"max": "82",
+					"min": 78,
+					"max": 82,
 					"item": "Potion of longevity"
 				},
 				{
-					"min": "83",
-					"max": "87",
+					"min": 83,
+					"max": 87,
 					"item": "Potion of vitality"
 				},
 				{
-					"min": "88",
-					"max": "92",
+					"min": 88,
+					"max": 92,
 					"item": "Spell scroll (8th level)"
 				},
 				{
-					"min": "93",
-					"max": "95",
+					"min": 93,
+					"max": 95,
 					"item": "Horseshoes of a zephyr"
 				},
 				{
-					"min": "96",
-					"max": "98",
+					"min": 96,
+					"max": 98,
 					"item": "Nolzur's marvelous pigments"
 				},
 				{
-					"min": "99",
-					"max": "99",
+					"min": 99,
+					"max": 99,
 					"item": "Bag of devouring"
 				},
 				{
-					"min": "100",
-					"max": "100",
+					"min": 100,
+					"max": 100,
 					"item": "Portable hole"
 				}
 			]
@@ -2177,38 +2226,38 @@ var lootdata =
 			"type": "E",
 			"table": [
 				{
-					"min": "1",
-					"max": "30",
+					"min": 1,
+					"max": 30,
 					"item": "Spell scroll (8th level)"
 				},
 				{
-					"min": "31",
-					"max": "55",
+					"min": 31,
+					"max": 55,
 					"item": "Potion of storm giant strength"
 				},
 				{
-					"min": "56",
-					"max": "70",
+					"min": 56,
+					"max": 70,
 					"item": "Potion of supreme healing"
 				},
 				{
-					"min": "71",
-					"max": "86",
+					"min": 71,
+					"max": 86,
 					"item": "Spell scroll (9th level)"
 				},
 				{
-					"min": "86",
-					"max": "93",
+					"min": 86,
+					"max": 93,
 					"item": "Universal solvent"
 				},
 				{
-					"min": "94",
-					"max": "98",
+					"min": 94,
+					"max": 98,
 					"item": "Arrow of slaying"
 				},
 				{
-					"min": "99",
-					"max": "100",
+					"min": 99,
+					"max": 100,
 					"item": "Sovereign glue"
 				}
 			]
@@ -2218,303 +2267,303 @@ var lootdata =
 			"type": "F",
 			"table": [
 				{
-					"min": "1",
-					"max": "15",
+					"min": 1,
+					"max": 15,
 					"item": "Weapon, +1"
 				},
 				{
-					"min": "16",
-					"max": "18",
+					"min": 16,
+					"max": 18,
 					"item": "Shield,+ 1"
 				},
 				{
-					"min": "19",
-					"max": "21",
+					"min": 19,
+					"max": 21,
 					"item": "Sentinel shield"
 				},
 				{
-					"min": "22",
-					"max": "23",
+					"min": 22,
+					"max": 23,
 					"item": "Amulet of proof against detection and location"
 				},
 				{
-					"min": "24",
-					"max": "25",
+					"min": 24,
+					"max": 25,
 					"item": "Boots of elvenkind"
 				},
 				{
-					"min": "26",
-					"max": "27",
+					"min": 26,
+					"max": 27,
 					"item": "Boots of striding and springing"
 				},
 				{
-					"min": "28",
-					"max": "29",
+					"min": 28,
+					"max": 29,
 					"item": "Bracers of archery"
 				},
 				{
-					"min": "30",
-					"max": "31",
+					"min": 30,
+					"max": 31,
 					"item": "Brooch of shielding"
 				},
 				{
-					"min": "32",
-					"max": "33",
+					"min": 32,
+					"max": 33,
 					"item": "Broom of flying"
 				},
 				{
-					"min": "34",
-					"max": "35",
+					"min": 34,
+					"max": 35,
 					"item": "Cloak of elvenkind"
 				},
 				{
-					"min": "36",
-					"max": "37",
+					"min": 36,
+					"max": 37,
 					"item": "Cloak of protection"
 				},
 				{
-					"min": "38",
-					"max": "39",
+					"min": 38,
+					"max": 39,
 					"item": "Gauntlets of ogre power"
 				},
 				{
-					"min": "40",
-					"max": "41",
+					"min": 40,
+					"max": 41,
 					"item": "Hat of disguise"
 				},
 				{
-					"min": "42",
-					"max": "43",
+					"min": 42,
+					"max": 43,
 					"item": "Javelin of lightning"
 				},
 				{
-					"min": "44",
-					"max": "45",
+					"min": 44,
+					"max": 45,
 					"item": "Pearl of power"
 				},
 				{
-					"min": "46",
-					"max": "47",
+					"min": 46,
+					"max": 47,
 					"item": "Rod of the pact keeper, + 1"
 				},
 				{
-					"min": "48",
-					"max": "49",
+					"min": 48,
+					"max": 49,
 					"item": "Slippers of spider climbing"
 				},
 				{
-					"min": "50",
-					"max": "51",
+					"min": 50,
+					"max": 51,
 					"item": "Staff of the adder"
 				},
 				{
-					"min": "52",
-					"max": "53",
+					"min": 52,
+					"max": 53,
 					"item": "Staff of the python"
 				},
 				{
-					"min": "54",
-					"max": "55",
+					"min": 54,
+					"max": 55,
 					"item": "Sword of vengeance"
 				},
 				{
-					"min": "56",
-					"max": "57",
+					"min": 56,
+					"max": 57,
 					"item": "Trident of fish command"
 				},
 				{
-					"min": "58",
-					"max": "59",
+					"min": 58,
+					"max": 59,
 					"item": "Wand of magic missiles"
 				},
 				{
-					"min": "60",
-					"max": "61",
+					"min": 60,
+					"max": 61,
 					"item": "Wand of the war mage, + 1"
 				},
 				{
-					"min": "62",
-					"max": "63",
+					"min": 62,
+					"max": 63,
 					"item": "Wand of web"
 				},
 				{
-					"min": "64",
-					"max": "65",
+					"min": 64,
+					"max": 65,
 					"item": "Weapon of warning"
 				},
 				{
-					"min": "66",
-					"max": "66",
+					"min": 66,
+					"max": 66,
 					"item": "Adamantine armor (chain mail)"
 				},
 				{
-					"min": "67",
-					"max": "67",
+					"min": 67,
+					"max": 67,
 					"item": "Adamantine armor (chain shirt)"
 				},
 				{
-					"min": "68",
-					"max": "68",
+					"min": 68,
+					"max": 68,
 					"item": "Adamantine armor (scale mail)"
 				},
 				{
-					"min": "69",
-					"max": "69",
+					"min": 69,
+					"max": 69,
 					"item": "Bag of tricks (gray)"
 				},
 				{
-					"min": "70",
-					"max": "70",
+					"min": 70,
+					"max": 70,
 					"item": "Bag of tricks (rust)"
 				},
 				{
-					"min": "71",
-					"max": "71",
+					"min": 71,
+					"max": 71,
 					"item": "Bag of tricks (tan)"
 				},
 				{
-					"min": "72",
-					"max": "72",
+					"min": 72,
+					"max": 72,
 					"item": "Boots of the winterlands"
 				},
 				{
-					"min": "73",
-					"max": "73",
+					"min": 73,
+					"max": 73,
 					"item": "Circlet of blasting"
 				},
 				{
-					"min": "74",
-					"max": "74",
+					"min": 74,
+					"max": 74,
 					"item": "Deck of illusions"
 				},
 				{
-					"min": "75",
-					"max": "75",
+					"min": 75,
+					"max": 75,
 					"item": "Eversmoking bottle"
 				},
 				{
-					"min": "76",
-					"max": "76",
+					"min": 76,
+					"max": 76,
 					"item": "Eyes of charming"
 				},
 				{
-					"min": "77",
-					"max": "77",
+					"min": 77,
+					"max": 77,
 					"item": "Eyes of the eagle"
 				},
 				{
-					"min": "78",
-					"max": "78",
+					"min": 78,
+					"max": 78,
 					"item": "Figurine of wondrous power (silver raven)"
 				},
 				{
-					"min": "79",
-					"max": "79",
+					"min": 79,
+					"max": 79,
 					"item": "Gem of brightness"
 				},
 				{
-					"min": "80",
-					"max": "80",
+					"min": 80,
+					"max": 80,
 					"item": "Gloves of missile snaring"
 				},
 				{
-					"min": "81",
-					"max": "81",
+					"min": 81,
+					"max": 81,
 					"item": "Gloves of swimming and climbing"
 				},
 				{
-					"min": "82",
-					"max": "82",
+					"min": 82,
+					"max": 82,
 					"item": "Gloves of thievery"
 				},
 				{
-					"min": "83",
-					"max": "83",
+					"min": 83,
+					"max": 83,
 					"item": "Headband of intellect"
 				},
 				{
-					"min": "84",
-					"max": "84",
+					"min": 84,
+					"max": 84,
 					"item": "Helm of telepathy"
 				},
 				{
-					"min": "85",
-					"max": "85",
+					"min": 85,
+					"max": 85,
 					"item": "Instrument of the bards (Doss lute)"
 				},
 				{
-					"min": "86",
-					"max": "86",
+					"min": 86,
+					"max": 86,
 					"item": "Instrument of the bards (Fochlucan bandore)"
 				},
 				{
-					"min": "87",
-					"max": "87",
+					"min": 87,
+					"max": 87,
 					"item": "Instrument of the bards (Mac-Fuimidh cittern)"
 				},
 				{
-					"min": "88",
-					"max": "88",
+					"min": 88,
+					"max": 88,
 					"item": "Medallion of thoughts"
 				},
 				{
-					"min": "89",
-					"max": "89",
+					"min": 89,
+					"max": 89,
 					"item": "Necklace of adaptation"
 				},
 				{
-					"min": "90",
-					"max": "90",
+					"min": 90,
+					"max": 90,
 					"item": "Periapt of wound closure"
 				},
 				{
-					"min": "91",
-					"max": "91",
+					"min": 91,
+					"max": 91,
 					"item": "Pipes of haunting"
 				},
 				{
-					"min": "92",
-					"max": "92",
+					"min": 92,
+					"max": 92,
 					"item": "Pipes of the sewers"
 				},
 				{
-					"min": "93",
-					"max": "93",
+					"min": 93,
+					"max": 93,
 					"item": "Ring of jumping"
 				},
 				{
-					"min": "94",
-					"max": "94",
+					"min": 94,
+					"max": 94,
 					"item": "Ring of mind shielding"
 				},
 				{
-					"min": "95",
-					"max": "95",
+					"min": 95,
+					"max": 95,
 					"item": "Ring of warmth"
 				},
 				{
-					"min": "96",
-					"max": "96",
+					"min": 96,
+					"max": 96,
 					"item": "Ring of water walking"
 				},
 				{
-					"min": "97",
-					"max": "97",
+					"min": 97,
+					"max": 97,
 					"item": "Quiver of Ehlonna"
 				},
 				{
-					"min": "98",
-					"max": "98",
+					"min": 98,
+					"max": 98,
 					"item": "Stone of good luck"
 				},
 				{
-					"min": "99",
-					"max": "99",
+					"min": 99,
+					"max": 99,
 					"item": "Wind fan"
 				},
 				{
-					"min": "100",
-					"max": "100",
+					"min": 100,
+					"max": 100,
 					"item": "Winged boots"
 				}
 			]
@@ -2524,13 +2573,13 @@ var lootdata =
 			"type": "G",
 			"table": [
 				{
-					"min": "1",
-					"max": "11",
+					"min": 1,
+					"max": 11,
 					"item": "Weapon, +2"
 				},
 				{
-					"min": "12",
-					"max": "14",
+					"min": 12,
+					"max": 14,
 					"item": "Figurine of wondrous power",
 					"table": [
 						"Bronze griffon",
@@ -2544,433 +2593,433 @@ var lootdata =
 					]
 				},
 				{
-					"min": "15",
-					"max": "15",
+					"min": 15,
+					"max": 15,
 					"item": "Adamantine armor (breastplate)"
 				},
 				{
-					"min": "16",
-					"max": "16",
+					"min": 16,
+					"max": 16,
 					"item": "Adamantine armor (splint)"
 				},
 				{
-					"min": "17",
-					"max": "17",
+					"min": 17,
+					"max": 17,
 					"item": "Amulet of health"
 				},
 				{
-					"min": "18",
-					"max": "18",
+					"min": 18,
+					"max": 18,
 					"item": "Armor of vulnerability"
 				},
 				{
-					"min": "19",
-					"max": "19",
+					"min": 19,
+					"max": 19,
 					"item": "Arrow-catching shield"
 				},
 				{
-					"min": "20",
-					"max": "20",
+					"min": 20,
+					"max": 20,
 					"item": "Belt of dwarvenkind"
 				},
 				{
-					"min": "21",
-					"max": "21",
+					"min": 21,
+					"max": 21,
 					"item": "Belt of hill giant strength"
 				},
 				{
-					"min": "22",
-					"max": "22",
+					"min": 22,
+					"max": 22,
 					"item": "Berserker axe"
 				},
 				{
-					"min": "23",
-					"max": "23",
+					"min": 23,
+					"max": 23,
 					"item": "Boots of levitation"
 				},
 				{
-					"min": "24",
-					"max": "24",
+					"min": 24,
+					"max": 24,
 					"item": "Boots of speed"
 				},
 				{
-					"min": "25",
-					"max": "25",
+					"min": 25,
+					"max": 25,
 					"item": "Bowl of commanding water elementals"
 				},
 				{
-					"min": "26",
-					"max": "26",
+					"min": 26,
+					"max": 26,
 					"item": "Bracers of defense"
 				},
 				{
-					"min": "27",
-					"max": "27",
+					"min": 27,
+					"max": 27,
 					"item": "Brazier of commanding fire elementals"
 				},
 				{
-					"min": "28",
-					"max": "28",
+					"min": 28,
+					"max": 28,
 					"item": "Cape of the mountebank"
 				},
 				{
-					"min": "29",
-					"max": "29",
+					"min": 29,
+					"max": 29,
 					"item": "Censer of controlling air elementals"
 				},
 				{
-					"min": "30",
-					"max": "30",
+					"min": 30,
+					"max": 30,
 					"item": "Armor, +1 chain mail"
 				},
 				{
-					"min": "31",
-					"max": "31",
+					"min": 31,
+					"max": 31,
 					"item": "Armor of resistance (chain mail)"
 				},
 				{
-					"min": "32",
-					"max": "32",
+					"min": 32,
+					"max": 32,
 					"item": "Armor,+1 chain shirt"
 				},
 				{
-					"min": "33",
-					"max": "33",
+					"min": 33,
+					"max": 33,
 					"item": "Armor of resistance (chain shirt)"
 				},
 				{
-					"min": "34",
-					"max": "34",
+					"min": 34,
+					"max": 34,
 					"item": "Cloak of displacement"
 				},
 				{
-					"min": "35",
-					"max": "35",
+					"min": 35,
+					"max": 35,
 					"item": "Cloak of the bat"
 				},
 				{
-					"min": "36",
-					"max": "36",
+					"min": 36,
+					"max": 36,
 					"item": "Cube afforce"
 				},
 				{
-					"min": "37",
-					"max": "37",
+					"min": 37,
+					"max": 37,
 					"item": "Daern's instant fortress"
 				},
 				{
-					"min": "38",
-					"max": "38",
+					"min": 38,
+					"max": 38,
 					"item": "Dagger of venom"
 				},
 				{
-					"min": "39",
-					"max": "39",
+					"min": 39,
+					"max": 39,
 					"item": "Dimensional shackles"
 				},
 				{
-					"min": "40",
-					"max": "40",
+					"min": 40,
+					"max": 40,
 					"item": "Dragon slayer"
 				},
 				{
-					"min": "41",
-					"max": "41",
+					"min": 41,
+					"max": 41,
 					"item": "Elven chain"
 				},
 				{
-					"min": "42",
-					"max": "42",
+					"min": 42,
+					"max": 42,
 					"item": "Flame tongue"
 				},
 				{
-					"min": "43",
-					"max": "43",
+					"min": 43,
+					"max": 43,
 					"item": "Gem of seeing"
 				},
 				{
-					"min": "44",
-					"max": "44",
+					"min": 44,
+					"max": 44,
 					"item": "Giant slayer"
 				},
 				{
-					"min": "45",
-					"max": "45",
+					"min": 45,
+					"max": 45,
 					"item": "Clamoured studded leather"
 				},
 				{
-					"min": "46",
-					"max": "46",
+					"min": 46,
+					"max": 46,
 					"item": "Helm of teleportation"
 				},
 				{
-					"min": "47",
-					"max": "47",
+					"min": 47,
+					"max": 47,
 					"item": "Horn of blasting"
 				},
 				{
-					"min": "48",
-					"max": "48",
+					"min": 48,
+					"max": 48,
 					"item": "Horn of Valhalla (silver or brass)"
 				},
 				{
-					"min": "49",
-					"max": "49",
+					"min": 49,
+					"max": 49,
 					"item": "Instrument of the bards (Canaith mandolin)"
 				},
 				{
-					"min": "50",
-					"max": "50",
+					"min": 50,
+					"max": 50,
 					"item": "Instrument ofthe bards (Cli lyre)"
 				},
 				{
-					"min": "51",
-					"max": "51",
+					"min": 51,
+					"max": 51,
 					"item": "Ioun stone (awareness)"
 				},
 				{
-					"min": "52",
-					"max": "52",
+					"min": 52,
+					"max": 52,
 					"item": "Ioun stone (protection)"
 				},
 				{
-					"min": "53",
-					"max": "53",
+					"min": 53,
+					"max": 53,
 					"item": "Ioun stone (reserve)"
 				},
 				{
-					"min": "54",
-					"max": "54",
+					"min": 54,
+					"max": 54,
 					"item": "Ioun stone (sustenance)"
 				},
 				{
-					"min": "55",
-					"max": "55",
+					"min": 55,
+					"max": 55,
 					"item": "Iron bands of Bilarro"
 				},
 				{
-					"min": "56",
-					"max": "56",
+					"min": 56,
+					"max": 56,
 					"item": "Armor, +1 leather"
 				},
 				{
-					"min": "57",
-					"max": "57",
+					"min": 57,
+					"max": 57,
 					"item": "Armor of resistance (leather)"
 				},
 				{
-					"min": "58",
-					"max": "58",
+					"min": 58,
+					"max": 58,
 					"item": "Mace of disruption"
 				},
 				{
-					"min": "59",
-					"max": "59",
+					"min": 59,
+					"max": 59,
 					"item": "Mace of smiting"
 				},
 				{
-					"min": "60",
-					"max": "60",
+					"min": 60,
+					"max": 60,
 					"item": "Mace of terror"
 				},
 				{
-					"min": "61",
-					"max": "61",
+					"min": 61,
+					"max": 61,
 					"item": "Mantle of spell resistance"
 				},
 				{
-					"min": "62",
-					"max": "62",
+					"min": 62,
+					"max": 62,
 					"item": "Necklace of prayer beads"
 				},
 				{
-					"min": "63",
-					"max": "63",
+					"min": 63,
+					"max": 63,
 					"item": "Periapt of proof against poison"
 				},
 				{
-					"min": "64",
-					"max": "64",
+					"min": 64,
+					"max": 64,
 					"item": "Ring of animal influence"
 				},
 				{
-					"min": "65",
-					"max": "65",
+					"min": 65,
+					"max": 65,
 					"item": "Ring of evasion"
 				},
 				{
-					"min": "66",
-					"max": "66",
+					"min": 66,
+					"max": 66,
 					"item": "Ring of feather falling"
 				},
 				{
-					"min": "67",
-					"max": "67",
+					"min": 67,
+					"max": 67,
 					"item": "Ring of free action"
 				},
 				{
-					"min": "68",
-					"max": "68",
+					"min": 68,
+					"max": 68,
 					"item": "Ring of protection"
 				},
 				{
-					"min": "69",
-					"max": "69",
+					"min": 69,
+					"max": 69,
 					"item": "Ring of resistance"
 				},
 				{
-					"min": "70",
-					"max": "70",
+					"min": 70,
+					"max": 70,
 					"item": "Ring of spell storing"
 				},
 				{
-					"min": "71",
-					"max": "71",
+					"min": 71,
+					"max": 71,
 					"item": "Ring of the ram"
 				},
 				{
-					"min": "72",
-					"max": "72",
+					"min": 72,
+					"max": 72,
 					"item": "Ring of X-ray vision"
 				},
 				{
-					"min": "73",
-					"max": "73",
+					"min": 73,
+					"max": 73,
 					"item": "Robe of eyes"
 				},
 				{
-					"min": "74",
-					"max": "74",
+					"min": 74,
+					"max": 74,
 					"item": "Rod of rulership"
 				},
 				{
-					"min": "75",
-					"max": "75",
+					"min": 75,
+					"max": 75,
 					"item": "Rod of the pact keeper, +2"
 				},
 				{
-					"min": "76",
-					"max": "76",
+					"min": 76,
+					"max": 76,
 					"item": "Rope of entanglement"
 				},
 				{
-					"min": "77",
-					"max": "77",
+					"min": 77,
+					"max": 77,
 					"item": "Armor, +1 scale mail"
 				},
 				{
-					"min": "78",
-					"max": "78",
+					"min": 78,
+					"max": 78,
 					"item": "Armor of resistance (scale mail)"
 				},
 				{
-					"min": "79",
-					"max": "79",
+					"min": 79,
+					"max": 79,
 					"item": "Shield, +2"
 				},
 				{
-					"min": "80",
-					"max": "80",
+					"min": 80,
+					"max": 80,
 					"item": "Shield of missile attraction"
 				},
 				{
-					"min": "81",
-					"max": "81",
+					"min": 81,
+					"max": 81,
 					"item": "Staff of charming"
 				},
 				{
-					"min": "82",
-					"max": "82",
+					"min": 82,
+					"max": 82,
 					"item": "Staff of healing"
 				},
 				{
-					"min": "83",
-					"max": "83",
+					"min": 83,
+					"max": 83,
 					"item": "Staff of swarming insects"
 				},
 				{
-					"min": "84",
-					"max": "84",
+					"min": 84,
+					"max": 84,
 					"item": "Staff of the woodlands"
 				},
 				{
-					"min": "85",
-					"max": "85",
+					"min": 85,
+					"max": 85,
 					"item": "Staff of withering"
 				},
 				{
-					"min": "86",
-					"max": "86",
+					"min": 86,
+					"max": 86,
 					"item": "Stone of controlling earth elementals"
 				},
 				{
-					"min": "87",
-					"max": "87",
+					"min": 87,
+					"max": 87,
 					"item": "Sun blade"
 				},
 				{
-					"min": "88",
-					"max": "88",
+					"min": 88,
+					"max": 88,
 					"item": "Sword of life stealing"
 				},
 				{
-					"min": "89",
-					"max": "89",
+					"min": 89,
+					"max": 89,
 					"item": "Sword of wounding"
 				},
 				{
-					"min": "90",
-					"max": "90",
+					"min": 90,
+					"max": 90,
 					"item": "Tentacle rod"
 				},
 				{
-					"min": "91",
-					"max": "91",
+					"min": 91,
+					"max": 91,
 					"item": "Vicious weapon"
 				},
 				{
-					"min": "92",
-					"max": "92",
+					"min": 92,
+					"max": 92,
 					"item": "Wand of binding"
 				},
 				{
-					"min": "93",
-					"max": "93",
+					"min": 93,
+					"max": 93,
 					"item": "Wand of enemy detection"
 				},
 				{
-					"min": "94",
-					"max": "94",
+					"min": 94,
+					"max": 94,
 					"item": "Wand of fear"
 				},
 				{
-					"min": "95",
-					"max": "95",
+					"min": 95,
+					"max": 95,
 					"item": "Wand of fireballs"
 				},
 				{
-					"min": "96",
-					"max": "96",
+					"min": 96,
+					"max": 96,
 					"item": "Wand of lightning bolts"
 				},
 				{
-					"min": "97",
-					"max": "97",
+					"min": 97,
+					"max": 97,
 					"item": "Wand of paralysis"
 				},
 				{
-					"min": "98",
-					"max": "98",
+					"min": 98,
+					"max": 98,
 					"item": "Wand of the war mage, +2"
 				},
 				{
-					"min": "99",
-					"max": "99",
+					"min": 99,
+					"max": 99,
 					"item": "Wand of wonder"
 				},
 				{
-					"min": "100",
-					"max": "100",
+					"min": 100,
+					"max": 100,
 					"item": "Wings of flying"
 				}
 			]
@@ -2980,348 +3029,348 @@ var lootdata =
 			"type": "H",
 			"table": [
 				{
-					"min": "1",
-					"max": "10",
+					"min": 1,
+					"max": 10,
 					"item": "Weapon, +3"
 				},
 				{
-					"min": "11",
-					"max": "12",
+					"min": 11,
+					"max": 12,
 					"item": "Amulet of the planes"
 				},
 				{
-					"min": "13",
-					"max": "14",
+					"min": 13,
+					"max": 14,
 					"item": "Carpet of flying"
 				},
 				{
-					"min": "15",
-					"max": "16",
+					"min": 15,
+					"max": 16,
 					"item": "Crystal ball (very rare version)"
 				},
 				{
-					"min": "17",
-					"max": "18",
+					"min": 17,
+					"max": 18,
 					"item": "Ring of regeneration"
 				},
 				{
-					"min": "19",
-					"max": "20",
+					"min": 19,
+					"max": 20,
 					"item": "Ring of shooting stars"
 				},
 				{
-					"min": "21",
-					"max": "22",
+					"min": 21,
+					"max": 22,
 					"item": "Ring of telekinesis"
 				},
 				{
-					"min": "23",
-					"max": "24",
+					"min": 23,
+					"max": 24,
 					"item": "Robe of scintillating colors"
 				},
 				{
-					"min": "25",
-					"max": "26",
+					"min": 25,
+					"max": 26,
 					"item": "Robe of stars"
 				},
 				{
-					"min": "27",
-					"max": "28",
+					"min": 27,
+					"max": 28,
 					"item": "Rod of absorption"
 				},
 				{
-					"min": "29",
-					"max": "30",
+					"min": 29,
+					"max": 30,
 					"item": "Rod of alertness"
 				},
 				{
-					"min": "31",
-					"max": "32",
+					"min": 31,
+					"max": 32,
 					"item": "Rod of security"
 				},
 				{
-					"min": "33",
-					"max": "34",
+					"min": 33,
+					"max": 34,
 					"item": "Rod of the pact keeper, +3"
 				},
 				{
-					"min": "35",
-					"max": "36",
+					"min": 35,
+					"max": 36,
 					"item": "Scimitar of speed"
 				},
 				{
-					"min": "37",
-					"max": "38",
+					"min": 37,
+					"max": 38,
 					"item": "Shield, +3"
 				},
 				{
-					"min": "39",
-					"max": "40",
+					"min": 39,
+					"max": 40,
 					"item": "Staff of fire"
 				},
 				{
-					"min": "41",
-					"max": "42",
+					"min": 41,
+					"max": 42,
 					"item": "Staff of frost"
 				},
 				{
-					"min": "43",
-					"max": "44",
+					"min": 43,
+					"max": 44,
 					"item": "Staff of power"
 				},
 				{
-					"min": "45",
-					"max": "46",
+					"min": 45,
+					"max": 46,
 					"item": "Staff of striking"
 				},
 				{
-					"min": "47",
-					"max": "48",
+					"min": 47,
+					"max": 48,
 					"item": "Staff of thunder and lightning"
 				},
 				{
-					"min": "49",
-					"max": "50",
+					"min": 49,
+					"max": 50,
 					"item": "Sword of sharpness"
 				},
 				{
-					"min": "51",
-					"max": "52",
+					"min": 51,
+					"max": 52,
 					"item": "Wand of polymorph"
 				},
 				{
-					"min": "53",
-					"max": "54",
+					"min": 53,
+					"max": 54,
 					"item": "Wand of the war mage, +3"
 				},
 				{
-					"min": "55",
-					"max": "55",
+					"min": 55,
+					"max": 55,
 					"item": "Adamantine armor (half plate)"
 				},
 				{
-					"min": "56",
-					"max": "56",
+					"min": 56,
+					"max": 56,
 					"item": "Adamantine armor (plate)"
 				},
 				{
-					"min": "57",
-					"max": "57",
+					"min": 57,
+					"max": 57,
 					"item": "Animated shield"
 				},
 				{
-					"min": "58",
-					"max": "58",
+					"min": 58,
+					"max": 58,
 					"item": "Belt of fire giant strength"
 				},
 				{
-					"min": "59",
-					"max": "59",
+					"min": 59,
+					"max": 59,
 					"item": "Belt of frost (or stone) giant strength"
 				},
 				{
-					"min": "60",
-					"max": "60",
+					"min": 60,
+					"max": 60,
 					"item": "Armor, + 1 breastplate"
 				},
 				{
-					"min": "61",
-					"max": "61",
+					"min": 61,
+					"max": 61,
 					"item": "Armor of resistance (breastplate)"
 				},
 				{
-					"min": "62",
-					"max": "62",
+					"min": 62,
+					"max": 62,
 					"item": "Candle of invocation"
 				},
 				{
-					"min": "63",
-					"max": "63",
+					"min": 63,
+					"max": 63,
 					"item": "Armor, +2 chain mail"
 				},
 				{
-					"min": "64",
-					"max": "64",
+					"min": 64,
+					"max": 64,
 					"item": "Armor, +2 chain shirt"
 				},
 				{
-					"min": "65",
-					"max": "65",
+					"min": 65,
+					"max": 65,
 					"item": "Cloak of Arachnida"
 				},
 				{
-					"min": "66",
-					"max": "66",
+					"min": 66,
+					"max": 66,
 					"item": "Dancing sword"
 				},
 				{
-					"min": "67",
-					"max": "67",
+					"min": 67,
+					"max": 67,
 					"item": "Demon armor"
 				},
 				{
-					"min": "68",
-					"max": "68",
+					"min": 68,
+					"max": 68,
 					"item": "Dragon scale mail"
 				},
 				{
-					"min": "69",
-					"max": "69",
+					"min": 69,
+					"max": 69,
 					"item": "Dwarven plate"
 				},
 				{
-					"min": "70",
-					"max": "70",
+					"min": 70,
+					"max": 70,
 					"item": "Dwarven thrower"
 				},
 				{
-					"min": "71",
-					"max": "71",
+					"min": 71,
+					"max": 71,
 					"item": "Efreeti bottle"
 				},
 				{
-					"min": "72",
-					"max": "72",
+					"min": 72,
+					"max": 72,
 					"item": "Figurine of wondrous power (obsidian steed)"
 				},
 				{
-					"min": "73",
-					"max": "73",
+					"min": 73,
+					"max": 73,
 					"item": "Frost brand"
 				},
 				{
-					"min": "74",
-					"max": "74",
+					"min": 74,
+					"max": 74,
 					"item": "Helm of brilliance"
 				},
 				{
-					"min": "75",
-					"max": "75",
+					"min": 75,
+					"max": 75,
 					"item": "Horn ofValhalla (bronze)"
 				},
 				{
-					"min": "76",
-					"max": "76",
+					"min": 76,
+					"max": 76,
 					"item": "Instrument of the bards (Anstruth harp)"
 				},
 				{
-					"min": "77",
-					"max": "77",
+					"min": 77,
+					"max": 77,
 					"item": "Ioun stone (absorption)"
 				},
 				{
-					"min": "78",
-					"max": "78",
+					"min": 78,
+					"max": 78,
 					"item": "Ioun stone (agility)"
 				},
 				{
-					"min": "79",
-					"max": "79",
+					"min": 79,
+					"max": 79,
 					"item": "Ioun stone (fortitude)"
 				},
 				{
-					"min": "80",
-					"max": "80",
+					"min": 80,
+					"max": 80,
 					"item": "Ioun stone (insight)"
 				},
 				{
-					"min": "81",
-					"max": "81",
+					"min": 81,
+					"max": 81,
 					"item": "Ioun stone (intellect)"
 				},
 				{
-					"min": "82",
-					"max": "82",
+					"min": 82,
+					"max": 82,
 					"item": "Ioun stone (leadership)"
 				},
 				{
-					"min": "83",
-					"max": "83",
+					"min": 83,
+					"max": 83,
 					"item": "Ioun stone (strength)"
 				},
 				{
-					"min": "84",
-					"max": "84",
+					"min": 84,
+					"max": 84,
 					"item": "Armor, +2 leather"
 				},
 				{
-					"min": "85",
-					"max": "85",
+					"min": 85,
+					"max": 85,
 					"item": "Manual of bodily health"
 				},
 				{
-					"min": "86",
-					"max": "86",
+					"min": 86,
+					"max": 86,
 					"item": "Manual of gainful exercise"
 				},
 				{
-					"min": "87",
-					"max": "87",
+					"min": 87,
+					"max": 87,
 					"item": "Manual of golems"
 				},
 				{
-					"min": "88",
-					"max": "88",
+					"min": 88,
+					"max": 88,
 					"item": "Manual of quickness of action"
 				},
 				{
-					"min": "89",
-					"max": "89",
+					"min": 89,
+					"max": 89,
 					"item": "Mirror of life trapping"
 				},
 				{
-					"min": "90",
-					"max": "90",
+					"min": 90,
+					"max": 90,
 					"item": "Nine lives stealer"
 				},
 				{
-					"min": "91",
-					"max": "91",
+					"min": 91,
+					"max": 91,
 					"item": "Oath bow"
 				},
 				{
-					"min": "92",
-					"max": "92",
+					"min": 92,
+					"max": 92,
 					"item": "Armor, +2 scale mail"
 				},
 				{
-					"min": "93",
-					"max": "93",
+					"min": 93,
+					"max": 93,
 					"item": "Spellguard shield"
 				},
 				{
-					"min": "94",
-					"max": "94",
+					"min": 94,
+					"max": 94,
 					"item": "Armor, + 1 splint"
 				},
 				{
-					"min": "95",
-					"max": "95",
+					"min": 95,
+					"max": 95,
 					"item": "Armor of resistance (splint)"
 				},
 				{
-					"min": "96",
-					"max": "96",
+					"min": 96,
+					"max": 96,
 					"item": "Armor, + 1 studded leather"
 				},
 				{
-					"min": "97",
-					"max": "97",
+					"min": 97,
+					"max": 97,
 					"item": "Armor of resistance (studded leather)"
 				},
 				{
-					"min": "98",
-					"max": "98",
+					"min": 98,
+					"max": 98,
 					"item": "Tome of clear thought"
 				},
 				{
-					"min": "99",
-					"max": "99",
+					"min": 99,
+					"max": 99,
 					"item": "Tome of leadership and influence"
 				},
 				{
-					"min": "100",
-					"max": "100",
+					"min": 100,
+					"max": 100,
 					"item": "Tome of understanding"
 				}
 			]
@@ -3331,148 +3380,148 @@ var lootdata =
 			"type": "I",
 			"table": [
 				{
-					"min": "1",
-					"max": "5",
+					"min": 1,
+					"max": 5,
 					"item": "Defender"
 				},
 				{
-					"min": "6",
-					"max": "10",
+					"min": 6,
+					"max": 10,
 					"item": "Hammer of thunderbolts"
 				},
 				{
-					"min": "11",
-					"max": "15",
+					"min": 11,
+					"max": 15,
 					"item": "Luck blade"
 				},
 				{
-					"min": "16",
-					"max": "20",
+					"min": 16,
+					"max": 20,
 					"item": "Sword of answering"
 				},
 				{
-					"min": "21",
-					"max": "23",
+					"min": 21,
+					"max": 23,
 					"item": "Holy avenger"
 				},
 				{
-					"min": "24",
-					"max": "26",
+					"min": 24,
+					"max": 26,
 					"item": "Ring of djinni summoning"
 				},
 				{
-					"min": "27",
-					"max": "29",
+					"min": 27,
+					"max": 29,
 					"item": "Ring of invisibility"
 				},
 				{
-					"min": "30",
-					"max": "32",
+					"min": 30,
+					"max": 32,
 					"item": "Ring of spell turning"
 				},
 				{
-					"min": "33",
-					"max": "35",
+					"min": 33,
+					"max": 35,
 					"item": "Rod of lordly might"
 				},
 				{
-					"min": "36",
-					"max": "38",
+					"min": 36,
+					"max": 38,
 					"item": "Staff of the magi"
 				},
 				{
-					"min": "39",
-					"max": "41",
+					"min": 39,
+					"max": 41,
 					"item": "Vorpal sword"
 				},
 				{
-					"min": "42",
-					"max": "43",
+					"min": 42,
+					"max": 43,
 					"item": "Belt of cloud giant strength"
 				},
 				{
-					"min": "44",
-					"max": "45",
+					"min": 44,
+					"max": 45,
 					"item": "Armor, +2 breastplate"
 				},
 				{
-					"min": "46",
-					"max": "47",
+					"min": 46,
+					"max": 47,
 					"item": "Armor, +3 chain mail"
 				},
 				{
-					"min": "48",
-					"max": "49",
+					"min": 48,
+					"max": 49,
 					"item": "Armor, +3 chain shirt"
 				},
 				{
-					"min": "50",
-					"max": "51",
+					"min": 50,
+					"max": 51,
 					"item": "Cloak of invisibility"
 				},
 				{
-					"min": "52",
-					"max": "53",
+					"min": 52,
+					"max": 53,
 					"item": "Crystal ball (legendary version)"
 				},
 				{
-					"min": "54",
-					"max": "55",
+					"min": 54,
+					"max": 55,
 					"item": "Armor, + 1 half plate"
 				},
 				{
-					"min": "56",
-					"max": "57",
+					"min": 56,
+					"max": 57,
 					"item": "Iron flask"
 				},
 				{
-					"min": "58",
-					"max": "59",
+					"min": 58,
+					"max": 59,
 					"item": "Armor, +3 leather"
 				},
 				{
-					"min": "60",
-					"max": "61",
+					"min": 60,
+					"max": 61,
 					"item": "Armor, +1 plate"
 				},
 				{
-					"min": "62",
-					"max": "63",
+					"min": 62,
+					"max": 63,
 					"item": "Robe of the Archmagi"
 				},
 				{
-					"min": "64",
-					"max": "65",
+					"min": 64,
+					"max": 65,
 					"item": "Rod of resurrection"
 				},
 				{
-					"min": "66",
-					"max": "67",
+					"min": 66,
+					"max": 67,
 					"item": "Armor, +1 scale mail"
 				},
 				{
-					"min": "68",
-					"max": "69",
+					"min": 68,
+					"max": 69,
 					"item": "Scarab of protection"
 				},
 				{
-					"min": "70",
-					"max": "71",
+					"min": 70,
+					"max": 71,
 					"item": "Armor, +2 splint"
 				},
 				{
-					"min": "72",
-					"max": "73",
+					"min": 72,
+					"max": 73,
 					"item": "Armor, +2 studded leather"
 				},
 				{
-					"min": "74",
-					"max": "75",
+					"min": 74,
+					"max": 75,
 					"item": "Well of many worlds"
 				},
 				{
-					"min": "76",
-					"max": "76",
+					"min": 76,
+					"max": 76,
 					"item": "Magic armor",
 					"table": [
 						"Armor, +2 half plate",
@@ -3490,123 +3539,123 @@ var lootdata =
 					]
 				},
 				{
-					"min": "77",
-					"max": "77",
+					"min": 77,
+					"max": 77,
 					"item": "Apparatus of Kwalish"
 				},
 				{
-					"min": "78",
-					"max": "78",
+					"min": 78,
+					"max": 78,
 					"item": "Armor of invulnerability"
 				},
 				{
-					"min": "79",
-					"max": "79",
+					"min": 79,
+					"max": 79,
 					"item": "Belt of storm giant strength"
 				},
 				{
-					"min": "80",
-					"max": "80",
+					"min": 80,
+					"max": 80,
 					"item": "Cubic gate"
 				},
 				{
-					"min": "81",
-					"max": "81",
+					"min": 81,
+					"max": 81,
 					"item": "Deck of many things"
 				},
 				{
-					"min": "82",
-					"max": "82",
+					"min": 82,
+					"max": 82,
 					"item": "Efreeti chain"
 				},
 				{
-					"min": "83",
-					"max": "83",
+					"min": 83,
+					"max": 83,
 					"item": "Armor of resistance (half plate)"
 				},
 				{
-					"min": "84",
-					"max": "84",
+					"min": 84,
+					"max": 84,
 					"item": "Horn of Valhalla (iron)"
 				},
 				{
-					"min": "85",
-					"max": "85",
+					"min": 85,
+					"max": 85,
 					"item": "Instrument of the bards (Ollamh harp)"
 				},
 				{
-					"min": "86",
-					"max": "86",
+					"min": 86,
+					"max": 86,
 					"item": "Ioun stone (greater absorption)"
 				},
 				{
-					"min": "87",
-					"max": "87",
+					"min": 87,
+					"max": 87,
 					"item": "Ioun stone (mastery)"
 				},
 				{
-					"min": "88",
-					"max": "88",
+					"min": 88,
+					"max": 88,
 					"item": "Ioun stone (regeneration)"
 				},
 				{
-					"min": "89",
-					"max": "89",
+					"min": 89,
+					"max": 89,
 					"item": "Plate armor of etherealness"
 				},
 				{
-					"min": "90",
-					"max": "90",
+					"min": 90,
+					"max": 90,
 					"item": "Plate armor of resistance"
 				},
 				{
-					"min": "91",
-					"max": "91",
+					"min": 91,
+					"max": 91,
 					"item": "Ring of air elemental command"
 				},
 				{
-					"min": "92",
-					"max": "92",
+					"min": 92,
+					"max": 92,
 					"item": "Ring of earth elemental command"
 				},
 				{
-					"min": "93",
-					"max": "93",
+					"min": 93,
+					"max": 93,
 					"item": "Ring of fire elemental command"
 				},
 				{
-					"min": "94",
-					"max": "94",
+					"min": 94,
+					"max": 94,
 					"item": "Ring of three wishes"
 				},
 				{
-					"min": "95",
-					"max": "95",
+					"min": 95,
+					"max": 95,
 					"item": "Ring of water elemental command"
 				},
 				{
-					"min": "96",
-					"max": "96",
+					"min": 96,
+					"max": 96,
 					"item": "Sphere of annihilation"
 				},
 				{
-					"min": "97",
-					"max": "97",
+					"min": 97,
+					"max": 97,
 					"item": "Talisman of pure good"
 				},
 				{
-					"min": "98",
-					"max": "98",
+					"min": 98,
+					"max": 98,
 					"item": "Talisman of the sphere"
 				},
 				{
-					"min": "99",
-					"max": "99",
+					"min": 99,
+					"max": 99,
 					"item": "Talisman of ultimate evil"
 				},
 				{
-					"min": "100",
-					"max": "100",
+					"min": 100,
+					"max": 100,
 					"item": "Tome of the stilled tongue"
 				}
 			]

--- a/js/history.js
+++ b/js/history.js
@@ -1,7 +1,3 @@
-const HASH_PART_SEP = ",";
-const HASH_LIST_SEP = "_";
-const HASH_START = "#";
-
 function hashchange(e) {
 	const [link, ...sub] = _getHashParts();
 

--- a/js/lootgen.js
+++ b/js/lootgen.js
@@ -1,26 +1,21 @@
+const LOOT_JSON_URL = "data/loot.json";
+const renderer = new EntryRenderer();
+let lootList;
 
-function randomNumber (min, max) {
-	return Math.floor(Math.random() * max) + min;
-}
+window.onload = function load() {
+	loadJSON(LOOT_JSON_URL, loadloot);
+};
 
-function numberWithCommas(x) {
-	return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-}
-
-window.onload = loadloot;
-
-function loadloot() {
-
+function loadloot(lootData) {
+	lootList = lootData;
 	// clear
 	$("button#clear").click(function() {
 		$("#lootoutput").html("");
 	});
-
 	// loot rolling button
 	$("button#genloot").click(function() {
 		rollLoot($("#cr").val(), $("#hoard").prop("checked"));
 	});
-
 	return;
 }
 
@@ -28,87 +23,59 @@ function loadloot() {
 function rollLoot(cr,hoard=false) {
 	$("#lootoutput > ul:eq(4), #lootoutput > hr:eq(4)").remove();
 	$("#lootoutput").prepend("<ul></ul><hr>")
-
 	// find the appropriate table based on CR and if hoard or individual
-	var tableset = hoard ? lootdata.hoard : lootdata.individual;
-	var curtable = null;
+	const tableset = hoard ? lootList.hoard : lootList.individual;
+	let curtable = null;
 	for (let i = 0; i < tableset.length; i++) {
-		if (cr >= parseInt(tableset[i].mincr) && cr <= parseInt(tableset[i].maxcr)) {
+		if (cr >= tableset[i].mincr && cr <= tableset[i].maxcr) {
 			curtable = tableset[i];
 			break;
 		}
 	}
-
 	if (!curtable) {
 		return;
 	}
-
-	//$("#lootoutput").html(JSON.stringify(curtable));
-
-
 	// roll on tables
-	var lootroll = randomNumber (1, 100);
-	var loottable = curtable.table;
-	var loot = null;
+	const lootroll = randomNumber (1, 100);
+	const loottable = curtable.table;
+	let loot = null;
 	for (let i = 0; i < loottable.length; i++) {
-		if (lootroll >= parseInt (loottable[i].min) && lootroll <= parseInt (loottable[i].max)) {
+		if (lootroll >= loottable[i].min && lootroll <= loottable[i].max) {
 			loot = loottable[i];
 			break;
 		}
 	}
-
 	if (!loot) {
 		return;
 	}
-
 	// take care of individual treasure
 	if (!hoard) {
-		const formattedCoins = getFormattedCoinsForDisplay(loot);
+		const formattedCoins = getFormattedCoinsForDisplay(loot.coins);
 		$("#lootoutput ul:eq(0)").prepend(`<li> ${formattedCoins} </li>`);
-
 		return;
-
 		// and now for hoards
 	} else {
 		const treasure = [];
-
 		treasure.push(getFormattedCoinsForDisplay(curtable.coins));
-
 		// gems and art objects
-
 		// check if it's gems or art objects
-		var artgems = (loot.gems || loot.artobjects) && loot.artobjects ? loot.artobjects : loot.gems;
-		var usingart = (loot.gems || loot.artobjects) && loot.artobjects ? true : false;
-
+		const artgems = (loot.gems || loot.artobjects) && loot.artobjects ? loot.artobjects : loot.gems;
+		const usingart = (loot.gems || loot.artobjects) && loot.artobjects ? true : false;
 		if (artgems) {
 			// get the appropriate table set
-			let artgemstable = (loot.gems || loot.artobjects) && loot.artobjects ? lootdata.artobjects : lootdata.gemstones;
+			let artgemstable = (loot.gems || loot.artobjects) && loot.artobjects ? lootList.artobjects : lootList.gemstones;
 			for (let i = 0; i < artgemstable.length; i++) {
 				if (artgemstable[i].type === artgems.type) {
 					artgemstable = artgemstable[i];
 					break;
 				}
 			}
-
 			// number of rolls on the table
 			const roll = droll.roll(artgems.amount).total;
 			const gems = [];
-
-			let gemartliststring = ""
-			if (usingart) {
-				gemartliststring += "<li>x"+roll+" "+numberWithCommas(artgems.type)+" gp art objects:<ul></ul></li>"
-			} else gemartliststring += "<li>x"+roll+" "+numberWithCommas(artgems.type)+" gp gemstones:<ul></ul></li>"
-			$("#lootoutput ul:eq(0)").append(gemartliststring)
-			for (let i = 0; i < roll; i++) {
-				const tableroll = randomNumber (0, artgemstable.table.length-1);
-				const gemstring = artgemstable.table[tableroll]
-				gems.push(gemstring);
-			}
-
-			for (let i = 0; i < gems.length; i++) {
-				$("#lootoutput ul:eq(0) ul:eq(0)").append("<li>"+gems[i]+"</li>");
-			}
-
+			$("#lootoutput ul:eq(0)").append("<li>x"+roll+" "+Parser._addCommas(artgems.type)+" gp "+(usingart ? "art objects" : "gemstones")+":<ul></ul></li>");
+			for (let i = 0; i < roll; i++) gems.push(artgemstable.table[randomNumber (0, artgemstable.table.length-1)]);
+			for (let i = 0; i < gems.length; i++) $("#lootoutput ul:eq(0) ul:eq(0)").append("<li>"+gems[i]+"</li>");
 			$("#lootoutput ul:eq(0) ul:eq(0) li").each(function() {
 				const curitem = this;
 				let curamount = 1;
@@ -123,10 +90,8 @@ function rollLoot(cr,hoard=false) {
 				}
 			})
 		}
-
 		// magic items
 		if (loot.magicitems) {
-
 			magicitemtabletype = [];
 			magicitemtableamounts = [];
 			magicitemtabletype.push(loot.magicitems.type.split(",")[0])
@@ -135,51 +100,37 @@ function rollLoot(cr,hoard=false) {
 				magicitemtabletype.push(loot.magicitems.type.split(",")[1])
 				magicitemtableamounts.push(loot.magicitems.amount.split(",")[1])
 			}
-
 			for (let v = 0; v < magicitemtabletype.length; v++) {
 				const curtype = magicitemtabletype[v];
 				const curamount = magicitemtableamounts[v];
-
 				// find the appropriate table
-				let magicitemstable = lootdata.magicitems;
+				let magicitemstable = lootList.magicitems;
 				for (let i = 0; i < magicitemstable.length; i++) {
 					if (magicitemstable[i].type === curtype) {
 						magicitemstable = magicitemstable[i];
 						break;
 					}
 				}
-
 				// number of rolls on the table
 				const roll = droll.roll(curamount).total;
 				const magicitems = [];
-
-				//$("#lootoutput ul:eq(0)").append("<li><span class='unselectable'>x"+roll+" magic items from table "+curtype+":</span><ul></ul></li>");
 				$("#lootoutput ul:eq(0) > li").last().append("<hr>");
 				for (let i = 0; i < roll; i++) {
-
 					let curmagicitem = null;
 					const itemroll = randomNumber(1,100);
 					for (let n = 0; n < magicitemstable.table.length; n++) {
-						if (itemroll >= parseInt(magicitemstable.table[n].min) && itemroll <= parseInt(magicitemstable.table[n].max)) {
+						if (itemroll >= magicitemstable.table[n].min && itemroll <= magicitemstable.table[n].max) {
 							curmagicitem = magicitemstable.table[n];
 							break;
 						}
 					}
-
-					let magicitemstring = curmagicitem.item;
+					let magicitemstring = parseLink(curmagicitem.item);
 					if (curmagicitem.table) {
 						magicitemstring += " (" + curmagicitem.table[randomNumber (0, curmagicitem.table.length-1)] + ")";
 					}
 					magicitems.push(magicitemstring);
 				}
-
-
-				for (let i = 0; i < magicitems.length; i++) {
-					//$("#lootoutput ul:eq(0) li:contains('table "+curtype+"') ul:eq(0)").append('<li>'+magicitems[i]+'</li>');
-					$("#lootoutput ul:eq(0)").append("<li class=\"magicitem\">"+magicitems[i]+"</li>");
-				}
-
-
+				for (let i = 0; i < magicitems.length; i++) $("#lootoutput ul:eq(0)").append("<li class=\"magicitem\">"+magicitems[i]+"</li>");
 				$("#lootoutput ul:eq(0) > li.magicitem").each(function() {
 					const curitem = this;
 					let curamount = 1;
@@ -193,15 +144,9 @@ function rollLoot(cr,hoard=false) {
 						$(curitem).prepend ("x"+curamount+" ");
 					}
 				})
-
 			}
 		}
-
-		for (let i = 0; i < treasure.length; i++) {
-			$("#lootoutput ul:eq(0)").prepend("<li>"+treasure[i]+"</li>");
-		}
-
-
+		for (let i = 0; i < treasure.length; i++) $("#lootoutput ul:eq(0)").prepend("<li>"+treasure[i]+"</li>");
 	}
 	return;
 }
@@ -213,18 +158,14 @@ function rollLoot(cr,hoard=false) {
  */
 function getFormattedCoinsForDisplay(loot){
 	const generatedCoins = generateCoinsFromLoot(loot);
-
 	const individuallyFormattedCoins = [];
 	generatedCoins.forEach((coin) => {
-		individuallyFormattedCoins.unshift("<li>"+ numberWithCommas(coin.value) + " " + coin.denomination + "</li>");
+		individuallyFormattedCoins.unshift("<li>"+ Parser._addCommas(coin.value) + " " + coin.denomination + "</li>");
 	});
-
-	const totalValueGP = getGPValueFromCoins(generatedCoins);
-
+	const totalValueGP = Parser._addCommas(getGPValueFromCoins(generatedCoins));
 	const combinedFormattedCoins = individuallyFormattedCoins.reduce((total, formattedCoin) => {
 		return total += formattedCoin;
 	}, "");
-
 	return `${totalValueGP} gp total<ul> ${combinedFormattedCoins}</ul>`;
 }
 
@@ -234,31 +175,23 @@ function getFormattedCoinsForDisplay(loot){
  */
 function generateCoinsFromLoot(loot){
 	const retVal = [];
-
 	const coins = [loot.cp, loot.sp, loot.ep, loot.gp, loot.pp]
 	const coinnames = ["cp","sp","ep","gp","pp"];
-
 	for (let i = coins.length-1; i >= 0; i--) {
 		if (!coins[i]){
 			continue;
 		} 
-
 		const roll = coins[i].split("*")[0];
 		const multiplier = coins[i].split("*")[1];
-
 		let rolledValue = droll.roll(roll).total;
-
 		if (multiplier){
 			rolledValue *= parseInt(multiplier);
 		}
-
 		const coin = {};
 		coin.denomination = coinnames[i];
 		coin.value = rolledValue;
-
 		retVal.push(coin);
 	}
-
 	return retVal;
 }
 
@@ -268,7 +201,6 @@ function generateCoinsFromLoot(loot){
  */
 function getGPValueFromCoins(coins){
 	const initialValue = 0;
-
 	const retVal = coins.reduce((total, coin) => {
 		switch(coin.denomination){
 			case "cp":
@@ -285,6 +217,17 @@ function getGPValueFromCoins(coins){
 				return total;
 		}
 	}, initialValue);
-
 	return parseFloat(retVal.toFixed(2));
+}
+
+function randomNumber (min, max) {
+	return Math.floor(Math.random() * max) + min;
+}
+
+function parseLink (rawText) {
+	if (rawText.startsWith("{@item ")) {
+		stack = [];
+		renderer.recursiveEntryRender(rawText, stack);
+		return stack.join("");
+	} else return rawText;
 }

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,3 +1,7 @@
+const HASH_PART_SEP = ",";
+const HASH_LIST_SEP = "_";
+const HASH_START = "#";
+
 STR_EMPTY = "";
 STR_VOID_LINK = "javascript:void(0)";
 STR_SLUG_DASH = "-";

--- a/lootgen.html
+++ b/lootgen.html
@@ -111,8 +111,8 @@
 	</footer>
 
 	<script type="text/javascript" src="js/utils.js"></script>
+	<script type="text/javascript" src="js/entryrender.js"></script>
 	<script type="text/javascript" src="js/lootgen.js"></script>
-	<script type="text/javascript" src="data/loot.json"></script>
 	<script type="text/javascript" src="lib/droll.js"></script>
 	<script type="text/javascript" src="lib/list.js"></script>
 	<script type="text/javascript" src="lib/jquery.js"></script>

--- a/test/alltests.js
+++ b/test/alltests.js
@@ -16,13 +16,13 @@ function validateSchema(){
 	results.push(validateClassesWith(validator));
 	results.push(validateVariantFeaturesWith(validator));
 	results.push(validateSpellsWith(validator));
+	results.push(validateLootWith(validator));
 
 	results.forEach( (result) => {
 		if(!result.valid){
 			errors = errors.concat(result.errors);
 		}
 	});
-
 
 	// Reporting
 	console.log(errors);
@@ -38,8 +38,7 @@ function validateSchema(){
 }
 
 /**
- * Reads and attaches all necessary helper subschemae 
- * to a Validator object.
+ * Reads and attaches all necessary helper subschemata to a Validator object.
  * @param  {jsonschema.Validator} validator The validator to attach the good stuff to
  * @return {void}
  */
@@ -57,24 +56,18 @@ function validateClassesWith(validator){
 	const classes = require("../data/classes.json");
 	return validator.validate(classes, classesSchema, {nestedErrors: true});
 }
-
-/**
- * Validates variantrules.json using its corresponding schema
- * @return {jsonschema.Result} The result of the validation.
- */
 function validateVariantFeaturesWith(validator){
 	const variantRulesSchema = require("./schema/variantrules.json");
 	const variantRules = require("../data/variantrules.json");
 	return validator.validate(variantRules, variantRulesSchema, {nestedErrors: true});
 }
-
-
-/**
- * Validates spells.json using its corresponding schema
- * @return {jsonschema.Result} The result of the validation.
- */
 function validateSpellsWith(validator){
 	const spellSchema = require("./schema/spells.json");
 	const spells = require("../data/spells.json");
 	return validator.validate(spells, spellSchema, {nestedErrors: true});
+}
+function validateLootWith(validator){
+	const lootSchema = require("./schema/loot.json");
+	const loot = require("../data/loot.json");
+	return validator.validate(loot, lootSchema, {nestedErrors: true});
 }

--- a/test/schema/loot.json
+++ b/test/schema/loot.json
@@ -1,0 +1,255 @@
+{
+	"$schema": "http://json-schema.org/draft-06/schema#",
+	"definitions": {
+		"cr": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 30,
+			"required": [
+				"type",
+				"minimum",
+				"maximum"
+			],
+			"additionalProperties": false
+		},
+		"d100": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 100,
+			"required": [
+				"type",
+				"minimum",
+				"maximum"
+			],
+			"additionalProperties": false
+		},
+		"coin": {
+			"type": "object",
+			"properties": {
+				"cp": {
+					"type": "string"
+				},
+				"sp": {
+					"type": "string"
+				},
+				"ep": {
+					"type": "string"
+				},
+				"gp": {
+					"type": "string"
+				},
+				"pp": {
+					"type": "string"
+				}
+			},
+			"additionalProperties": false
+		},
+		"lootTypeAmount": {
+			"type": "object",
+			"properties": {
+				"type": {
+					"type": "string"
+				},
+				"amount": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"amount"
+			],
+			"additionalProperties": false
+		},
+		"gems_or_art": {
+			"type": "array",
+			"uniqueItems": true,
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"type": {
+						"type": "string"
+					},
+					"table": {
+						"type": "array",
+						"uniqueItems": true,
+						"items": {
+							"type": "string"
+						}
+					}
+				},
+				"required": [
+					"name",
+					"type",
+					"table"
+				],
+				"additionalProperties": false
+			}
+		}
+	},
+	"type": "object",
+	"properties": {
+		"individual": {
+			"type": "array",
+			"uniqueItems": true,
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"mincr": {
+						"$ref": "#/definitions/cr"
+					},
+					"maxcr": {
+						"$ref": "#/definitions/cr"
+					},
+					"table": {
+						"type": "array",
+						"uniqueItems": true,
+						"items": {
+							"type": "object",
+							"properties": {
+								"min": {
+									"$ref": "#/definitions/d100"
+								},
+								"max": {
+									"$ref": "#/definitions/d100"
+								},
+								"coins": {
+									"$ref": "#/definitions/coin"
+								}
+							},
+							"required": [
+								"min",
+								"max",
+								"coins"
+							],
+							"additionalProperties": false
+						}
+					}
+				},
+				"required": [
+					"name",
+					"mincr",
+					"maxcr",
+					"table"
+				],
+				"additionalProperties": false
+			}
+		},
+		"hoard": {
+			"type": "array",
+			"uniqueItems": true,
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"mincr": {
+						"$ref": "#/definitions/cr"
+					},
+					"maxcr": {
+						"$ref": "#/definitions/cr"
+					},
+					"coins": {
+						"$ref": "#/definitions/coin"
+					},
+					"table": {
+						"type": "array",
+						"uniqueItems": true,
+						"items": {
+							"type": "object",
+							"properties": {
+								"min": {
+									"$ref": "#/definitions/d100"
+								},
+								"max": {
+									"$ref": "#/definitions/d100"
+								},
+								"gems": {
+									"$ref": "#/definitions/lootTypeAmount"
+								},
+								"artobjects": {
+									"$ref": "#/definitions/lootTypeAmount"
+								},
+								"magicitems": {
+									"$ref": "#/definitions/lootTypeAmount"
+								}
+							},
+							"required": [
+								"min",
+								"max"
+							],
+							"additionalProperties": false
+						}
+					}
+				},
+				"required": [
+					"name",
+					"mincr",
+					"maxcr",
+					"coins",
+					"table"
+				],
+				"additionalProperties": false
+			}
+		},
+		"gemstones": {
+			"$ref": "#/definitions/gems_or_art"
+		},
+		"artobjects": {
+			"$ref": "#/definitions/gems_or_art"
+		},
+		"magicitems": {
+			"type": "array",
+			"uniqueItems": true,
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"type": {
+						"type": "string"
+					},
+					"table": {
+						"type": "array",
+						"uniqueItems": true,
+						"items": {
+							"type": "object",
+							"properties": {
+								"min": {
+									"$ref": "#/definitions/d100"
+								},
+								"max": {
+									"$ref": "#/definitions/d100"
+								},
+								"item": {
+									"type": "string"
+								}
+							}
+						}
+					}
+				},
+				"required": [
+					"name",
+					"type",
+					"table"
+				],
+				"additionalProperties": false
+			}
+		}
+	},
+	"required": [
+		"individual",
+		"hoard",
+		"gemstones",
+		"artobjects",
+		"magicitems"
+	],
+	"additionalProperties": false
+}


### PR DESCRIPTION
**data/items.json**
More duplication removed.
Started to add renderer-usable data, e.g. in Axe of the Dwarvish Lords and replacing some `<a>...</a>` tags with inline `{@...}` entries.

**data/loot.json**
Restructured to be better JSON (and it's also pure JSON too).
Started to add some renderable links for the magic items.

**js/history.js**
Moved HASH constants to **utils.js** as not every page uses **history.js** but they all use **utils.js**.

**js/lootgen.js**
Felt like a complete rewrite, but it probably wasn't quite that bad.

**js/utils.js**
Added HASH constants from **history.js**.

**lootgen.html**
Added **entryrender.js** and removed **loot.json**.

**test/alltests.js**
Added schema validation for **loot.json**.

**test/schema/loot.json**
JSON schema definition for **data/loot.json**.