### PR TITLE
(chore) item refactoring

### DIFF
--- a/data/basicitems.json
+++ b/data/basicitems.json
@@ -235,7 +235,13 @@
 			"source": "PHB",
 			"page": "149",
 			"entries": [
-				"Special. You have disadvantage when you use a lance to attack a target within 5 feet of you. Also, a lance requires two hands to wield when you aren't mounted."
+				{
+					"type": "entries",
+					"name": "Special",
+					"entries": [
+						"You have disadvantage when you use a lance to attack a target within 5 feet of you. Also, a lance requires two hands to wield when you aren't mounted."
+					]
+				}
 			]
 		},
 		{
@@ -352,7 +358,13 @@
 			"source": "PHB",
 			"page": "149",
 			"entries": [
-				"Special. A Large or smaller creature hit by a net is restrained until it is freed. A net has no effect on creatures that are formless, or creatures that are Huge or larger. A creature can use its action to make a DC 10 Strength check, freeing itself or another creature within its reach on a success. Dealing 5 slashing damage to the net (AC 10) also frees the creature without harming it, ending the effect and destroying the net. When you use an action, bonus action, or reaction to attack with a net, you can make only one attack regardless of the number of attacks you can normally make."
+				{
+					"type": "entries",
+					"name": "Special",
+					"entries": [
+						"A Large or smaller creature hit by a net is restrained until it is freed. A net has no effect on creatures that are formless, or creatures that are Huge or larger. A creature can use its action to make a DC 10 Strength check, freeing itself or another creature within its reach on a success. Dealing 5 slashing damage to the net (AC 10) also frees the creature without harming it, ending the effect and destroying the net. When you use an action, bonus action, or reaction to attack with a net, you can make only one attack regardless of the number of attacks you can normally make."
+					]
+				}
 			]
 		},
 		{
@@ -577,7 +589,7 @@
 			"weight": "3",
 			"dmg1": "1d10",
 			"dmgType": "P",
-			"property": "A,LD",
+			"property": "AF,LD",
 			"range": "30/90",
 			"source": "DMG",
 			"page": "268"
@@ -594,7 +606,7 @@
 			"weight": "10",
 			"dmg1": "1d12",
 			"dmgType": "P",
-			"property": "A,LD,2H",
+			"property": "AF,LD,2H",
 			"range": "40/120",
 			"source": "DMG",
 			"page": "268"
@@ -610,7 +622,7 @@
 			"weight": "3",
 			"dmg1": "2d6",
 			"dmgType": "P",
-			"property": "A,RLD",
+			"property": "AF,RLD",
 			"range": "50/150",
 			"reload": "15",
 			"source": "DMG",
@@ -627,7 +639,7 @@
 			"weight": "3",
 			"dmg1": "2d8",
 			"dmgType": "P",
-			"property": "A,RLD",
+			"property": "AF,RLD",
 			"range": "40/120",
 			"reload": "6",
 			"source": "DMG",
@@ -644,7 +656,7 @@
 			"weight": "8",
 			"dmg1": "2d10",
 			"dmgType": "P",
-			"property": "A,RLD,2H",
+			"property": "AF,RLD,2H",
 			"range": "80/240",
 			"reload": "5",
 			"source": "DMG",
@@ -661,7 +673,7 @@
 			"weight": "8",
 			"dmg1": "2d8",
 			"dmgType": "P",
-			"property": "A,BF,RLD,2H",
+			"property": "AF,BF,RLD,2H",
 			"range": "80/240",
 			"reload": "30",
 			"source": "DMG",
@@ -678,7 +690,7 @@
 			"weight": "7",
 			"dmg1": "2d8",
 			"dmgType": "P",
-			"property": "A,RLD,2H",
+			"property": "AF,RLD,2H",
 			"range": "30/90",
 			"reload": "2",
 			"source": "DMG",
@@ -695,7 +707,7 @@
 			"weight": "2",
 			"dmg1": "3d6",
 			"dmgType": "R",
-			"property": "A,RLD",
+			"property": "AF,RLD",
 			"range": "30/120",
 			"reload": "50",
 			"source": "DMG",
@@ -712,7 +724,7 @@
 			"weight": "10",
 			"dmg1": "6d8",
 			"dmgType": "N",
-			"property": "A,RLD,2H",
+			"property": "AF,RLD,2H",
 			"range": "120/360",
 			"reload": "2",
 			"source": "DMG",
@@ -729,7 +741,7 @@
 			"weight": "7",
 			"dmg1": "3d8",
 			"dmgType": "R",
-			"property": "A,RLD,2H",
+			"property": "AF,RLD,2H",
 			"range": "100/300",
 			"reload": "30",
 			"source": "DMG",
@@ -738,6 +750,7 @@
 		{
 			"name": "Arrow",
 			"type": "A",
+			"ammunition": true,
 			"rarity": "None",
 			"value": "5cp",
 			"weight": "0.05",
@@ -747,6 +760,7 @@
 		{
 			"name": "Arrows (20)",
 			"type": "A",
+			"ammunition": true,
 			"rarity": "None",
 			"value": "1gp",
 			"weight": "1",
@@ -756,6 +770,7 @@
 		{
 			"name": "Blowgun Needle",
 			"type": "A",
+			"ammunition": true,
 			"rarity": "None",
 			"value": "2cp",
 			"weight": "0.02",
@@ -765,6 +780,7 @@
 		{
 			"name": "Blowgun Needles (50)",
 			"type": "A",
+			"ammunition": true,
 			"rarity": "None",
 			"value": "1gp",
 			"weight": "1",
@@ -774,6 +790,7 @@
 		{
 			"name": "Crossbow Bolt",
 			"type": "A",
+			"ammunition": true,
 			"rarity": "None",
 			"value": "5cp",
 			"weight": "0.075",
@@ -783,6 +800,7 @@
 		{
 			"name": "Crossbow Bolts (20)",
 			"type": "A",
+			"ammunition": true,
 			"rarity": "None",
 			"value": "1gp",
 			"weight": "1.5",
@@ -792,6 +810,7 @@
 		{
 			"name": "Sling Bullet",
 			"type": "A",
+			"ammunition": true,
 			"rarity": "None",
 			"value": "0.2cp",
 			"weight": "0.075",
@@ -801,6 +820,7 @@
 		{
 			"name": "Sling Bullets (20)",
 			"type": "A",
+			"ammunition": true,
 			"rarity": "None",
 			"value": "4cp",
 			"weight": "1.5",
@@ -809,7 +829,8 @@
 		},
 		{
 			"name": "Renaissance Bullets (10)",
-			"type": "A",
+			"type": "AF",
+			"ammunition": true,
 			"age": "Renaissance",
 			"rarity": "None",
 			"value": "3gp",
@@ -819,7 +840,8 @@
 		},
 		{
 			"name": "Modern Bullets (10)",
-			"type": "A",
+			"type": "AF",
+			"ammunition": true,
 			"age": "Modern",
 			"rarity": "None",
 			"weight": "1",
@@ -828,7 +850,8 @@
 		},
 		{
 			"name": "Energy Cell",
-			"type": "A",
+			"type": "AF",
+			"ammunition": true,
 			"age": "Futuristic",
 			"rarity": "None",
 			"weight": "0.3125",
@@ -1040,6 +1063,269 @@
 			"page": "144",
 			"entries": [
 				"A shield is made from wood or metal and is carried in one hand. Wielding a shield increases your Armor Class by 2. You can benefit from only one shield at a time."
+			]
+		}
+	],
+	"itemProperty": [
+		{
+			"abbreviation": "A",
+			"source": "PHB",
+			"page": "146",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Ammunition",
+					"entries": [
+						"You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. Loading a one-handed weapon requires a free hand. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield."
+					]
+				},
+				"If you use a weapon that has the ammunition property to make a melee attack, you treat the weapon as an improvised weapon. A sling must be loaded to deal any damage when used in this way."
+			]
+		},
+		{
+			"abbreviation": "AF",
+			"source": "DMG",
+			"page": "267",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Ammunition",
+					"entries": [
+						"You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. Loading a one-handed weapon requires a free hand. The ammunition of a firearm is destroyed upon use."
+					]
+				},
+				"If you use a weapon that has the ammunition property to make a melee attack, you treat the weapon as an improvised weapon. A sling must be loaded to deal any damage when used in this way."
+			]
+		},
+		{
+			"abbreviation": "BF",
+			"source": "DMG",
+			"page": "267",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Burst Fire",
+					"entries": [
+						"A weapon that has the burst fire property can make a single-target attack, or it can spray a 10-foot-cube area within normal range with shots. Each creature in the area must succeed on a DC 15 Dexterity saving throw or take the weapon's normal damage. This action uses ten pieces of ammunition."
+					]
+				}
+			]
+		},
+		{
+			"abbreviation": "F",
+			"source": "PHB",
+			"page": "147",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Finesse",
+					"entries": [
+						"When making an attack with a finesse weapon, you use your choice of your Strength or Dexterity modifier for the attack and damage rolls. You must use the same modifier for both rolls."
+					]
+				}
+			]
+		},
+		{
+			"abbreviation": "H",
+			"source": "PHB",
+			"page": "147",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Heavy",
+					"entries": [
+						"Small creatures have disadvantage on attack rolls with heavy weapons. A heavy weapon's size and bulk make it too large for a Small creature to use effectively."
+					]
+				}
+			]
+		},
+		{
+			"abbreviation": "L",
+			"source": "PHB",
+			"page": "147",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Light",
+					"entries": [
+						"A light weapon is small and easy to handle, making it ideal for use when fighting with two weapons."
+					]
+				}
+			]
+		},
+		{
+			"abbreviation": "LD",
+			"source": "PHB",
+			"page": "147",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Loading",
+					"entries": [
+						"Because of the time required to load this weapon, you can fire only one piece of ammunition from it when you use an action, bonus action, or reaction to fire it, regardless of the number of attacks you can normally make."
+					]
+				}
+			]
+		},
+		{
+			"abbreviation": "R",
+			"source": "PHB",
+			"page": "147",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Reach",
+					"entries": [
+						"This weapon adds 5 feet to your reach when you attack with it. This property also determines your reach for opportunity attacks with a reach weapon."
+					]
+				}
+			]
+		},
+		{
+			"abbreviation": "RLD",
+			"source": "DMG",
+			"page": "267",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Reload",
+					"entries": [
+						"A limited number of shots can be made with a weapon that has the reload property. A character must then reload it using an action or a bonus action (the character's choice)."
+					]
+				}
+			]
+		},
+		{
+			"abbreviation": "S",
+			"source": "PHB",
+			"page": "147",
+			"name": "special"
+		},
+		{
+			"abbreviation": "T",
+			"source": "PHB",
+			"page": "147",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Thrown",
+					"entries": [
+						"If a weapon has the thrown property, you can throw the weapon to make a ranged attack. If the weapon is a melee weapon, you use the same ability modifier for that attack roll and damage roll that you would use for a melee attack with the weapon. For example, if you throw a handaxe, you use your Strength, but if you throw a dagger, you can use either your Strength or your Dexterity, since the dagger has the finesse property."
+					]
+				}
+			]
+		},
+		{
+			"abbreviation": "2H",
+			"source": "PHB",
+			"page": "147",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Two-Handed",
+					"entries": [
+						"This weapon requires two hands to use. This property is relevant only when you attack with the weapon, not when you simply hold it."
+					]
+				}
+			]
+		},
+		{
+			"abbreviation": "V",
+			"source": "PHB",
+			"page": "147",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Versatile",
+					"entries": [
+						"This weapon can be used with one or two hands. A damage value in parentheses appears with the property \u2014 the damage when the weapon is used with two hands to make a melee attack."
+					]
+				}
+			]
+		}
+	],
+	"itemType": [
+		{
+			"abbreviation": "A",
+			"source": "PHB",
+			"page": "146",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Ammunition",
+					"entries": [
+						"You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. Loading a one-handed weapon requires a free hand. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield."
+					]
+				},
+				"If you use a weapon that has the ammunition property to make a melee attack, you treat the weapon as an improvised weapon. A sling must be loaded to deal any damage when used in this way."
+			]
+		},
+		{
+			"abbreviation": "AF",
+			"source": "DMG",
+			"page": "267",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Ammunition",
+					"entries": [
+						"You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. Loading a one-handed weapon requires a free hand. The ammunition of a firearm is destroyed upon use."
+					]
+				},
+				"If you use a weapon that has the ammunition property to make a melee attack, you treat the weapon as an improvised weapon. A sling must be loaded to deal any damage when used in this way."
+			]
+		},
+		{
+			"abbreviation": "AT",
+			"source": "PHB",
+			"page": "154",
+			"name": "Artisan Tools",
+			"entries": [
+				"These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency."
+			]
+		},
+		{
+			"abbreviation": "GS",
+			"source": "PHB",
+			"page": "154",
+			"name": "Gaming Set",
+			"entries": [
+				"If you are proficient with a gaming set, you can add your proficiency bonus to ability checks you make to play a game with that set. Each type of gaming set requires a separate proficiency."
+			]
+		},
+		{
+			"abbreviation": "INS",
+			"source": "PHB",
+			"page": "154",
+			"name": "Instrument",
+			"entries": [
+				"If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.",
+				"A bard can use a musical instrument as a spellcasting focus, substituting it for any material component that does not list a cost.",
+				"Each type of musical instrument requires a separate proficiency."
+			]
+		},
+		{
+			"abbreviation": "R",
+			"source": "PHB",
+			"page": "146",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Range",
+					"entries": [
+						"A weapon that can be used to make a ranged attack has a range shown in parentheses after the ammunition or thrown property. The range lists two numbers. The first is the weapon's normal range in feet, and the second indicates the weapon's maximum range. When attacking a target beyond normal range, you have disadvantage on the attack roll. You can't attack a target beyond the weapon's long range."
+					]
+				}
+			]
+		},
+		{
+			"abbreviation": "TG",
+			"source": "PHB",
+			"page": "146",
+			"name": "Trade Good",
+			"entries": [
+				"Most wealth is not in coins. It is measured in livestock, grain, land, rights to collect taxes, or rights to resources (such as a mine or a forest).",
+				"Guilds, nobles, and royalty regulate trade. Chartered companies are granted rights to conduct trade along certain routes, to send merchant ships to various ports, or to buy or sell specific goods. Guilds set prices for the goods or services that they control, and determine who may or may not offer those goods and services. Merchants commonly exchange trade goods without using currency."
 			]
 		}
 	]

--- a/data/items.json
+++ b/data/items.json
@@ -1216,6 +1216,7 @@
 		{
 			"name": "Armor of Invulnerability",
 			"type": "HA",
+			"armor": true,
 			"weight": "65",
 			"ac": "18",
 			"strength": "15",
@@ -1232,6 +1233,7 @@
 		{
 			"name": "Armor of Vulnerability (Bludgeoning)",
 			"type": "HA",
+			"armor": true,
 			"weight": "65",
 			"ac": "18",
 			"strength": "15",
@@ -1249,6 +1251,7 @@
 		{
 			"name": "Armor of Vulnerability (Piercing)",
 			"type": "HA",
+			"armor": true,
 			"weight": "65",
 			"ac": "18",
 			"strength": "15",
@@ -1266,6 +1269,7 @@
 		{
 			"name": "Armor of Vulnerability (Slashing)",
 			"type": "HA",
+			"armor": true,
 			"weight": "65",
 			"ac": "18",
 			"strength": "15",
@@ -1946,6 +1950,7 @@
 		{
 			"name": "Black Dragon Scale Mail",
 			"type": "MA",
+			"armor": true,
 			"weight": "45",
 			"ac": "14",
 			"stealth": true,
@@ -2082,6 +2087,7 @@
 		{
 			"name": "Blue Dragon Scale Mail",
 			"type": "MA",
+			"armor": true,
 			"weight": "45",
 			"ac": "14",
 			"stealth": true,
@@ -2294,6 +2300,7 @@
 		{
 			"name": "Brass Dragon Scale Mail",
 			"type": "MA",
+			"armor": true,
 			"weight": "45",
 			"ac": "14",
 			"stealth": true,
@@ -2332,6 +2339,7 @@
 		{
 			"name": "Bronze Dragon Scale Mail",
 			"type": "MA",
+			"armor": true,
 			"weight": "45",
 			"ac": "14",
 			"stealth": true,
@@ -2909,6 +2917,7 @@
 		{
 			"name": "Copper Dragon Scale Mail",
 			"type": "MA",
+			"armor": true,
 			"weight": "45",
 			"ac": "14",
 			"stealth": true,
@@ -3512,6 +3521,7 @@
 		{
 			"name": "Demon Armor",
 			"type": "HA",
+			"armor": true,
 			"weight": "65",
 			"ac": "18",
 			"strength": "15",
@@ -3806,6 +3816,7 @@
 		{
 			"name": "Dwarven Plate",
 			"type": "HA",
+			"armor": true,
 			"weight": "65",
 			"ac": "18",
 			"strength": "15",
@@ -3878,6 +3889,7 @@
 		{
 			"name": "Efreeti Chain",
 			"type": "HA",
+			"armor": true,
 			"weight": "55",
 			"ac": "16",
 			"strength": "13",
@@ -3976,6 +3988,7 @@
 		{
 			"name": "Elven Chain",
 			"type": "MA",
+			"armor": true,
 			"weight": "20",
 			"ac": "13",
 			"tier": "Major",
@@ -4385,6 +4398,7 @@
 		{
 			"name": "Glamoured Studded Leather",
 			"type": "LA",
+			"armor": true,
 			"weight": "13",
 			"ac": "13",
 			"tier": "Major",
@@ -4491,6 +4505,7 @@
 		{
 			"name": "Gold Dragon Scale Mail",
 			"type": "MA",
+			"armor": true,
 			"weight": "45",
 			"ac": "14",
 			"stealth": true,
@@ -4543,6 +4558,7 @@
 		{
 			"name": "Green Dragon Scale Mail",
 			"type": "MA",
+			"armor": true,
 			"weight": "45",
 			"ac": "14",
 			"stealth": true,
@@ -7433,6 +7449,7 @@
 		{
 			"name": "Red Dragon Scale Mail",
 			"type": "MA",
+			"armor": true,
 			"weight": "45",
 			"ac": "14",
 			"stealth": true,
@@ -8627,6 +8644,7 @@
 		{
 			"name": "Silver Dragon Scale Mail",
 			"type": "MA",
+			"armor": true,
 			"weight": "45",
 			"ac": "14",
 			"stealth": true,
@@ -11138,7 +11156,7 @@
 			"reqAttune": "YES",
 			"entries": [
 				"Crafted by the drow, this slim black wand has 7 charges. While holding it, you can use an action to expend 1 of its charges to cause a small glob of viscous material to launch from the tip at one creature within 60 feet of you. Make a ranged attack roll against the target, with a bonus equal to your spellcasting modifier (or your Intelligence modifier, if you don't have a spellcasting modifier) plus your proficiency bonus. On a hit, the glob expands and dries on the target, which is restrained for 1 hour. After that time, the viscous material cracks and falls away.",
-				"Applying a pint or more of alcohol to the restrained creature dissolves the glob instantly, as does the application of <a href=\"items.html#oil%20of%20etherealness\" target=\"_blank\">oil of etherealness_dmg</a> or <a href=\"items.html#universal%20solvent_dmg\" target=\"_blank\">universal solvent</a>. The glob also dissolves instantly if exposed to sunlight. No other nonmagical process can remove the viscous material until it deteriorates on its own.",
+				"Applying a pint or more of alcohol to the restrained creature dissolves the glob instantly, as does the application of {@item oil of etherealness|dmg} or {@item universal solvent|dmg}. The glob also dissolves instantly if exposed to sunlight. No other nonmagical process can remove the viscous material until it deteriorates on its own.",
 				"The wand regains 1d6+1 expended charges daily at midnight. If you expend the wands last charge, roll a d20. On a 1, the wand melts into harmless slime and is destroyed.",
 				"A wand of viscous globs is destroyed if exposed to sunlight for 1 hour without interruption."
 			]
@@ -11453,6 +11471,7 @@
 		{
 			"name": "White Dragon Scale Mail",
 			"type": "MA",
+			"armor": true,
 			"weight": "45",
 			"ac": "14",
 			"stealth": true,
@@ -12775,6 +12794,7 @@
 		{
 			"name": "Scorpion Armor",
 			"type": "HA",
+			"armor": true,
 			"weight": "65",
 			"ac": "18",
 			"strength": "15",

--- a/data/items.json
+++ b/data/items.json
@@ -8146,7 +8146,7 @@
 			"entries": [
 				"This rod has a flanged head and the following properties.",
 				"Alertness. While holding the rod, you have advantage on Wisdom (Perception) checks and on rolls for initiative.",
-				"Spells. While holding the rod, you can use an action to cast one of the following spells from it: {@spell detect evil and good|phb}, {@spell detect magic|phb}, <a href=\"spells.html#detect%20poison%20and%20disease_phb\" target=\"_blank\">detect poison and disease</a>, or see <a href=\"spells.html#invisibility_phb\" target=\"_blank\">invisibility</a>.",
+				"Spells. While holding the rod, you can use an action to cast one of the following spells from it: {@spell detect evil and good|phb}, {@spell detect magic|phb}, {@spell detect poison and disease|phb}, or {@spell see invisibility|phb}.",
 				"Protective Aura. As an action, you can plant the haft end of the rod in the ground, whereupon the rod's head sheds bright light in a 60-foot radius and dim light for an additional 60 feet. While in that bright light, you and any creature that is friendly to you gain a +1 bonus to AC and saving throws and can sense the location of any invisible hostile creature that is also in the bright light.",
 				"The rod's head stops glowing and the effect ends after 10 minutes, or when a creature uses an action to pull the rod from the ground. This property can't be used again until the next dawn."
 			]
@@ -8227,6 +8227,22 @@
 			"entries": [
 				"While holding this rod, you gain a +1 bonus to spell attack rolls and to the saving throw DCs of your warlock spells.",
 				"In addition, you can regain one warlock spell slot as an action while holding the rod. You can't use this property again until you finish a long rest."
+			],
+			"modifier": [
+				{
+					"_category": "bonus",
+					"__text": "spell attack +1",
+					"toString": [
+						null
+					]
+				},
+				{
+					"_category": "bonus",
+					"__text": "spell dc +1",
+					"toString": [
+						null
+					]
+				}
 			]
 		},
 		{
@@ -8241,6 +8257,22 @@
 			"entries": [
 				"While holding this rod, you gain a +2 bonus to spell attack rolls and to the saving throw DCs of your warlock spells.",
 				"In addition, you can regain one warlock spell slot as an action while holding the rod. You can't use this property again until you finish a long rest."
+			],
+			"modifier": [
+				{
+					"_category": "bonus",
+					"__text": "spell attack +2",
+					"toString": [
+						null
+					]
+				},
+				{
+					"_category": "bonus",
+					"__text": "spell dc +2",
+					"toString": [
+						null
+					]
+				}
 			]
 		},
 		{
@@ -8255,6 +8287,22 @@
 			"entries": [
 				"While holding this rod, you gain a +3 bonus to spell attack rolls and to the saving throw DCs of your warlock spells.",
 				"In addition, you can regain one warlock spell slot as an action while holding the rod. You can't use this property again until you finish a long rest."
+			],
+			"modifier": [
+				{
+					"_category": "bonus",
+					"__text": "spell attack +3",
+					"toString": [
+						null
+					]
+				},
+				{
+					"_category": "bonus",
+					"__text": "spell dc +3",
+					"toString": [
+						null
+					]
+				}
 			]
 		},
 		{

--- a/data/magicvariants.json
+++ b/data/magicvariants.json
@@ -550,7 +550,7 @@
 				"You have a +1 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical."
 			],
 			"requires": {
-				"type": "A"
+				"ammunition": true
 			},
 			"inherits": {
 				"genericBonus": "+1",
@@ -587,7 +587,7 @@
 				"You have a +2 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical."
 			],
 			"requires": {
-				"type": "A"
+				"ammunition": true
 			},
 			"inherits": {
 				"genericBonus": "+2",
@@ -624,7 +624,7 @@
 				"You have a +3 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical."
 			],
 			"requires": {
-				"type": "A"
+				"ammunition": true
 			},
 			"inherits": {
 				"genericBonus": "+3",
@@ -658,7 +658,7 @@
 			"name": "Walloping Ammunition",
 			"type": "MV",
 			"requires": {
-				"type": "A"
+				"ammunition": true
 			},
 			"inherits": {
 				"tier": "Minor",

--- a/data/magicvariants.json
+++ b/data/magicvariants.json
@@ -368,17 +368,6 @@
 			}
 		},
 		{
-			"name": "Armor of Vulnerability",
-			"type": "MV",
-			"entries": [
-				"While wearing this armor, you have resistance to one of the following damage types: bludgeoning, piercing, or slashing.",
-				"Curse. This armor is cursed, a fact that is revealed only when an identify spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by the {@spell remove curse|phb} spell or similar magic; removing the armor fails to end the curse. While cursed you have vulnerability to piercing and slashing damage."
-			],
-			"requires": {
-				"name": "Does not match with any name"
-			}
-		},
-		{
 			"name": "Adamantine Armor",
 			"type": "MV",
 			"requires": {

--- a/js/items.js
+++ b/js/items.js
@@ -31,6 +31,15 @@ function addVariants(basicItemData) {
 function mergeBasicItems(variantData) {
 	variantList = variantData.variant;
 	itemList = itemList.concat(basicItemList);
+	for (let i = 0; i < variantList.length; i++) {
+		variantList[i].tier = variantList[i].inherits.tier;
+		variantList[i].rarity = variantList[i].inherits.rarity;
+		variantList[i].source = variantList[i].inherits.source;
+		variantList[i].page = variantList[i].inherits.page;
+		if(!variantList[i].entries && variantList[i].inherits.entries) variantList[i].entries=JSON.parse(JSON.stringify(variantList[i].inherits.entries));
+		if(variantList[i].requires.armor) variantList[i].armor = variantList[i].requires.armor
+	}
+	itemList = itemList.concat(variantList);
 	for (let i = 0; i < basicItemList.length; i++) {
 		const curBasicItem = basicItemList[i];
 		if(curBasicItem.entries === undefined) curBasicItem.entries=[];

--- a/js/items.js
+++ b/js/items.js
@@ -5,6 +5,8 @@ const TYPE_DOSH ="$";
 let tabledefault = "";
 let itemList;
 let basicItemList;
+const propertyList = {};
+const typeList = {};
 let variantList;
 
 window.onload = function load() {
@@ -18,17 +20,17 @@ function addBasicItems(itemData) {
 
 function addVariants(basicItemData) {
 	basicItemList = basicItemData.basicitem;
+	const itemPropertyList = basicItemData.itemProperty;
+	const itemTypeList = basicItemData.itemType;
+	// Convert the property and type list JSONs into look-ups, i.e. use the abbreviation as a JSON property name
+	for (let i = 0; i < itemPropertyList.length; i++) propertyList[itemPropertyList[i].abbreviation] = itemPropertyList[i].name ? JSON.parse(JSON.stringify(itemPropertyList[i])) : {"name": itemPropertyList[i].entries[0].name.toLowerCase(), "entries": itemPropertyList[i].entries};
+	for (let i = 0; i < itemTypeList.length; i++) typeList[itemTypeList[i].abbreviation] = itemTypeList[i].name ? JSON.parse(JSON.stringify(itemTypeList[i])): {"name": itemTypeList[i].entries[0].name.toLowerCase(), "entries": itemTypeList[i].entries};
 	loadJSON(MAGIC_VARIANTS_JSON_URL, mergeBasicItems);
-}
-
-function emphasize (strongWords, normalWords) { // FIX ME: Replace HTML tags with inline tags if still needed
-	return "<p><b><i>"+strongWords+".</i></b> "+normalWords+"</p>";
 }
 
 function mergeBasicItems(variantData) {
 	variantList = variantData.variant;
 	itemList = itemList.concat(basicItemList);
-
 	for (let i = 0; i < basicItemList.length; i++) {
 		const curBasicItem = basicItemList[i];
 		if(curBasicItem.entries === undefined) curBasicItem.entries=[];
@@ -52,7 +54,7 @@ function mergeBasicItems(variantData) {
 						} else if (inheritedProperty === "nameSuffix") {
 							const tmpName = tmpBasicItem.name;
 							tmpBasicItem.name = tmpName.indexOf(" (") !== -1 ? tmpName.replace(" (", curInherits.nameSuffix+" (") : tmpName+curInherits.nameSuffix;
-						} else if (inheritedProperty === "text") {
+						} else if (inheritedProperty === "entries") {
 							for (let k = curInherits.entries.length-1; k > -1; k--) {
 								let tmpText = curInherits.entries[k];
 								if (tmpBasicItem.dmgType) tmpText = tmpText.replace("{@dmgType}", Parser.dmgTypeToFull(tmpBasicItem.dmgType));
@@ -70,7 +72,39 @@ function mergeBasicItems(variantData) {
 	enhanceItems();
 }
 
-function enhanceItems() { //FIX ME Move the texthtml processing from loadhash to here to make life easier for the renderer
+function pushObject(targetObject, objectToBePushed) {
+	let copiedObject = JSON.parse(JSON.stringify(targetObject));
+	copiedObject.push(objectToBePushed);
+	return copiedObject;
+}
+
+function enhanceItems() {
+	for (let i = 0; i < itemList.length; i++) {
+		const item = itemList[i];
+		if (item.entries === undefined) itemList[i].entries=[];
+		if (item.type && typeList[item.type]) for (let j = 0; j < typeList[item.type].entries.length; j++) itemList[i].entries = pushObject(itemList[i].entries,typeList[item.type].entries[j]);
+		if (item.property) {
+			const properties = item.property.split(",");
+			for (let j = 0; j < properties.length; j++) if (propertyList[properties[j]].entries) for (let k = 0; k < propertyList[properties[j]].entries.length; k++) itemList[i].entries = pushObject(itemList[i].entries,propertyList[properties[j]].entries[k]);
+		}
+		//The following could be encoded in JSON, but they depend on more than one JSON property; maybe fix if really bored later
+		if (item.armor) {
+			if (item.resist) itemList[i].entries = pushObject(itemList[i].entries,"You have resistance to "+item.resist+" damage while you wear this armor.");
+			if (item.armor && item.stealth) itemList[i].entries = pushObject(itemList[i].entries,"The wearer has disadvantage on Stealth (Dexterity) checks.");
+			if (item.type === "HA" && item.strength) itemList[i].entries = pushObject(itemList[i].entries,"If the wearer has a Strength score lower than " + item.strength + ", their speed is reduced by 10 feet.");
+		} else if (item.resist) {
+			if (item.type === "P") itemList[i].entries = pushObject(itemList[i].entries,"When you drink this potion, you gain resistance to "+item.resist+" damage for 1 hour.");
+			if (item.type === "RG") itemList[i].entries = pushObject(itemList[i].entries,"You have resistance to "+item.resist+" damage while wearing this ring.");
+		}
+		if (item.type === "SCF") {
+			if (item.scfType === "arcane") itemList[i].entries = pushObject(itemList[i].entries,"An arcane focus is a special item designed to channel the power of arcane spells. A sorcerer, warlock, or wizard can use such an item as a spellcasting focus, using it in place of any material component which does not list a cost.");
+			if (item.scfType === "druid") itemList[i].entries = pushObject(itemList[i].entries,"A druid can use such a druidic focus as a spellcasting focus, using it in place of any material component that does not have a cost.");
+			if (item.scfType === "holy") {
+				itemList[i].entries = pushObject(itemList[i].entries,"A holy symbol is a representation of a god or pantheon.");
+				itemList[i].entries = pushObject(itemList[i].entries,"A cleric or paladin can use a holy symbol as a spellcasting focus, using it in place of any material components which do not list a cost. To use the symbol in this way, the caster must hold it in hand, wear it visibly, or bear it on a shield.");
+			}
+		}
+	}
 	populateTablesAndFilters();
 }
 
@@ -295,8 +329,7 @@ function loadhash (id) {
 
 	$("span#damage").html("");
 	$("span#damagetype").html("");
-	let type = "";
-	if (item.type) type = item.type;
+	const type = item.type || "";
 	if (item.weaponCategory) {
 		if(item.dmg1) $("span#damage").html(utils_makeRoller(item.dmg1));
 		if(item.dmgType) $("span#damagetype").html(Parser.dmgTypeToFull(item.dmgType));
@@ -315,6 +348,20 @@ function loadhash (id) {
 		}
 	}
 
+	$("span#properties").html("");
+	if (item.property) {
+		const properties = item.property.split(",");
+		for (let i = 0; i < properties.length; i++) {
+			let a = b = properties[i];
+			a = propertyList[a].name;
+			if (b === "V") a = a + " (" + utils_makeRoller(item.dmg2) + ")";
+			if (b === "T" || b === "A" || b === "AF") a = a + " (" + item.range + "ft.)";
+			if (b === "RLD") a = a + " (" + item.reload + " shots)";
+			a = (i > 0 ? ", " : (item.dmg1 ? "- " : "")) + a;
+			$("span#properties").append(a);
+		}
+	}
+
 	$("tr.text").remove();
 	let texthtml = "";
 	if (item.entries) {
@@ -324,69 +371,12 @@ function loadhash (id) {
 		texthtml = renderStack.join("");
 	}
 
-	const ammoGenericText="<p>If you use a weapon that has the ammunition property to make a melee attack, you treat the weapon as an improvised weapon. A sling must be loaded to deal any damage when used in this way.</p>";
-	const ammoFirearmText=emphasize("Ammunition", "You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. The ammunition of a firearm is destroyed upon use.")+ammoGenericText;
-	const ammoNormalText=emphasize("Ammunition", "You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.")+ammoGenericText;
-	if (type === "LA" ||type === "MA"|| type === "HA") {
-		if (item.resist) texthtml += "<p>You have resistance to "+item.resist+" damage while you wear this armor.</p>";
-		if (type === "HA" && item.strength) texthtml += "<p>If the wearer has a Strength score lower than " + item.strength + ", their speed is reduced by 10 feet.</p>";
-		if (item.stealth) texthtml += "<p>The wearer has disadvantage on Stealth (Dexterity) checks.</p>";
-	} else if (type === "A") {
-		texthtml += item.age ? ammoFirearmText : ammoNormalText;
-	} else if (type === "AT") {
-		texthtml += "<p>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</p>";
-	} else if (type === "GS") {
-		texthtml += "<p>If you are proficient with a gaming set, you can add your proficiency bonus to ability checks you make to play a game with that set. Each type of gaming set requires a separate proficiency.</p>";
-	} else if (type === "INS") {
-		texthtml += "<p>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</p><p>A bard can use a musical instrument as a spellcasting focus, substituting it for any material component that does not list a cost.</p><p>Each type of musical instrument requires a separate proficiency.</p>";
-	} else if (type === "P") {
-		if (item.resist) texthtml += "<p>When you drink this potion, you gain resistance to "+item.resist+" damage for 1 hour.</p>";
-	} else if (type === "RG") {
-		if (item.resist) texthtml += "<p>You have resistance to "+item.resist+" damage while wearing this ring.</p>";
-	} else if (type === "SCF") {
-		if (item.scfType === "arcane") texthtml += "<p>An arcane focus is a special item designed to channel the power of arcane spells. A sorcerer, warlock, or wizard can use such an item as a spellcasting focus, using it in place of any material component which does not list a cost.</p>";
-		if (item.scfType === "druid") texthtml += "<p>A druid can use such a druidic focus as a spellcasting focus, using it in place of any material component that does not have a cost.</p>";
-		if (item.scfType === "holy") texthtml += "<p>A holy symbol is a representation of a god or pantheon.</p><p>A cleric or paladin can use a holy symbol as a spellcasting focus, using it in place of any material components which do not list a cost. To use the symbol in this way, the caster must hold it in hand, wear it visibly, or bear it on a shield.</p>";
-	} else if (type === "TG") {
-		texthtml += "<p>Most wealth is not in coins. It is measured in livestock, grain, land, rights to collect taxes, or rights to resources (such as a mine or a forest).</p><p>Guilds, nobles, and royalty regulate trade. Chartered companies are granted rights to conduct trade along certain routes, to send merchant ships to various ports, or to buy or sell specific goods. Guilds set prices for the goods or services that they control, and determine who may or may not offer those goods and services. Merchants commonly exchange trade goods without using currency.</p>";
-	}
-	if (type === "R") texthtml += emphasize("Range", "A weapon that can be used to make a ranged attack has a range shown in parentheses after the ammunition or thrown property. The range lists two numbers. The first is the weapon's normal range in feet, and the second indicates the weapon's maximum range. When attacking a target beyond normal range, you have disadvantage on the attack roll. You can't attack a target beyond the weapon's long range.");
-
-	$("span#properties").html("");
-	if (item.property) {
-		const properties = item.property.split(",");
-		for (let i = 0; i < properties.length; i++) {
-			let a = b = properties[i];
-			a = Parser.propertyToAbv (a);
-			if (b === "V") {
-				a = a + " (" + utils_makeRoller(item.dmg2) + ")";
-				texthtml += emphasize("Versatile", "This weapon can be used with one or two hands. A damage value in parentheses appears with the property \u2014 the damage when the weapon is used with two hands to make a melee attack.");
-			}
-			if (b === "T" || b === "A") a = a + " (" + item.range + "ft.)";
-			if (b === "RLD") {
-				a = a + " (" + item.reload + " shots)";
-				texthtml += emphasize("Reload", "A limited number of shots can be made with a weapon that has the reload property. A character must then reload it using an action or a bonus action (the character's choice).");
-			}
-			a = (i > 0 ? ", " : (item.dmg1 ? "- " : "")) + a;
-			$("span#properties").append(a);
-			if (b === "2H") texthtml += emphasize("Two-Handed", "This weapon requires two hands to use.");
-			if (b === "A") texthtml += item.age ? ammoFirearmText : ammoNormalText;
-			if (b === "BF") texthtml += emphasize("Burst Fire", "A weapon that has the burst fire property can make a single-target attack, or it can spray a 10-foot-cube area within normal range with shots. Each creature in the area must succeed on a DC 15 Dexterity saving throw or take the weapon's normal damage. This action uses ten pieces of ammunition.");
-			if (b === "F") texthtml += emphasize("Finesse", "When making an attack with a finesse weapon, you use your choice of your Strength or Dexterity modifier for the attack and damage rolls. You must use the same modifier for both rolls.");
-			if (b === "H") texthtml += emphasize("Heavy", "Small creatures have disadvantage on attack rolls with heavy weapons. A heavy weapon's size and bulk make it too large for a Small creature to use effectively.");
-			if (b === "L") texthtml += emphasize("Light", "A light weapon is small and easy to handle, making it ideal for use when fighting with two weapons.");
-			if (b === "LD") texthtml += emphasize("Loading", "Because of the time required to load this weapon, you can fire only one piece of ammunition from it when you use an action, bonus action, or reaction to fire it, regardless of the number of attacks you can normally make.");
-			if (b === "R") texthtml += emphasize("Reach", "This weapon adds 5 feet to your reach when you attack with it.");
-			if (b === "T") texthtml += emphasize("Thrown", "If a weapon has the thrown property, you can throw the weapon to make a ranged attack. If the weapon is a melee weapon, you use the same ability modifier for that attack roll and damage roll that you would use for a melee attack with the weapon. For example, if you throw a handaxe, you use your Strength, but if you throw a dagger, you can use either your Strength or your Dexterity, since the dagger has the finesse property.");
-		}
-	}
-
 	$("tr#text").after("<tr class='text'><td colspan='6' class='text1'>"+utils_makeRoller(texthtml)+"</td></tr>");
 	$(".items span.roller").contents().unwrap();
 	$("#stats span.roller").click(function() {
-		var roll =$(this).attr("data-roll").replace(/\s+/g, "");
-		var rollresult =  droll.roll(roll);
-		var name = $("#name").clone().children().remove().end().text();
+		let roll =$(this).attr("data-roll").replace(/\s+/g, "");
+		let rollresult =  droll.roll(roll);
+		let name = $("#name").clone().children().remove().end().text();
 		$("div#output").prepend("<span>"+name + ": <em>"+roll+"</em> rolled for <strong>"+rollresult.total+"</strong> (<em>"+rollresult.rolls.join(", ")+"</em>)<br></span>").show();
 		$("div#output span:eq(5)").remove();
 	})

--- a/js/items.js
+++ b/js/items.js
@@ -73,7 +73,7 @@ function mergeBasicItems(variantData) {
 }
 
 function pushObject(targetObject, objectToBePushed) {
-	let copiedObject = JSON.parse(JSON.stringify(targetObject));
+	const copiedObject = JSON.parse(JSON.stringify(targetObject));
 	copiedObject.push(objectToBePushed);
 	return copiedObject;
 }
@@ -374,9 +374,9 @@ function loadhash (id) {
 	$("tr#text").after("<tr class='text'><td colspan='6' class='text1'>"+utils_makeRoller(texthtml)+"</td></tr>");
 	$(".items span.roller").contents().unwrap();
 	$("#stats span.roller").click(function() {
-		let roll =$(this).attr("data-roll").replace(/\s+/g, "");
-		let rollresult =  droll.roll(roll);
-		let name = $("#name").clone().children().remove().end().text();
+		const roll =$(this).attr("data-roll").replace(/\s+/g, "");
+		const rollresult =  droll.roll(roll);
+		const name = $("#name").clone().children().remove().end().text();
 		$("div#output").prepend("<span>"+name + ": <em>"+roll+"</em> rolled for <strong>"+rollresult.total+"</strong> (<em>"+rollresult.rolls.join(", ")+"</em>)<br></span>").show();
 		$("div#output span:eq(5)").remove();
 	})

--- a/js/utils.js
+++ b/js/utils.js
@@ -581,10 +581,6 @@ Parser.numberToString= function (num) {
 	}
 };
 
-Parser.propertyToAbv = function (property) {
-	return Parser._parse_aToB(Parser.PROPERTY_JSON_TO_ABV, property);
-};
-
 // sp-prefix functions are for parsing spell data, and shared with the roll20 script
 Parser.spSchoolAbvToFull= function (school) {
 	return Parser._parse_aToB(Parser.SP_SCHOOL_ABV_TO_FULL, school);
@@ -1021,6 +1017,7 @@ Parser.SOURCE_JSON_TO_ABV[SRC_ToB_3PP] 		= "ToB (3pp)";
 
 Parser.ITEM_TYPE_JSON_TO_ABV = {
 	"A": "Ammunition",
+	"AF": "Ammunition",
 	"AT": "Artisan Tool",
 	"EXP": "Explosive",
 	"G": "Adventuring Gear",
@@ -1057,21 +1054,6 @@ Parser.DMGTYPE_JSON_TO_FULL = {
 Parser.NUMBERS_ONES = ['','one','two','three','four','five','six','seven','eight','nine'];
 Parser.NUMBERS_TENS = ['','','twenty','thirty','forty','fifty','sixty','seventy','eighty','ninety'];
 Parser.NUMBERS_TEENS = ['ten','eleven','twelve','thirteen','fourteen','fifteen','sixteen','seventeen','eighteen','nineteen'];
-
-Parser.PROPERTY_JSON_TO_ABV = {
-	"2H": "two-handed",
-	"A": "ammunition",
-	"BF": "burst fire",
-	"F": "finesse",
-	"H": "heavy",
-	"L": "light",
-	"LD": "loading",
-	"R": "reach",
-	"RLD": "reload",
-	"S": "special",
-	"T": "thrown",
-	"V": "versatile"
-};
 
 // SOURCES =============================================================================================================
 function hasBeenReprinted(shortName, source) {

--- a/test/schema/basicitems.json
+++ b/test/schema/basicitems.json
@@ -1,5 +1,62 @@
 {
 	"$schema": "http://json-schema.org/draft-06/schema#",
+	"definitions": {
+		"itemLookup": {
+			"type": "array",
+			"uniqueItems": true,
+			"items": {
+				"type": "object",
+				"properties": {
+					"abbreviation": {
+						"type": "string"
+					},
+					"source": {
+						"type": "string"
+					},
+					"page": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"entries": {
+						"type": "array",
+						"items": {
+							"$ref": "/Entry"
+						}
+					}
+				},
+				"anyOf" : [
+					{
+						"required": [
+							"abbreviation",
+							"source",
+							"page",
+							"name",
+							"entries"
+						]
+					},
+					{
+						"required": [
+							"abbreviation",
+							"source",
+							"page",
+							"entries"
+						]
+					},
+					{
+						"required": [
+							"abbreviation",
+							"source",
+							"page",
+							"name"
+						]
+					}
+				],
+				"additionalProperties": false
+			}
+		}
+	},
 	"type": "object",
 	"properties": {
 		"basicitem": {
@@ -28,6 +85,9 @@
 					},
 					"age": {
 						"type": "string"
+					},
+					"ammunition": {
+						"type": "boolean"
 					},
 					"armor": {
 						"type": "boolean"
@@ -93,6 +153,13 @@
 				],
 				"additionalProperties": false
 			}
+		},
+		"itemProperty": {
+			"$ref": "#/definitions/itemLookup"
+		},
+		"itemType": {
+			"$ref": "#/definitions/itemLookup"
 		}
-	}
+	},
+	"additionalProperties": false
 }

--- a/test/schema/items.json
+++ b/test/schema/items.json
@@ -1,0 +1,145 @@
+{
+	"$schema": "http://json-schema.org/draft-06/schema#",
+	"type": "object",
+	"properties": {
+		"item": {
+			"type": "array",
+			"uniqueItems": true,
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"type": {
+						"type": "string"
+					},
+					"rarity": {
+						"type": "string"
+					},
+					"source": {
+						"type": "string"
+					},
+					"page": {
+						"type": "string"
+					},
+					"ac": {
+						"type": "string"
+					},
+					"age": {
+						"type": "string"
+					},
+					"ammunition": {
+						"type": "boolean"
+					},
+					"armor": {
+						"type": "boolean"
+					},
+					"axe": {
+						"type": "boolean"
+					},
+					"carryingcapacity": {
+						"type": "string"
+					},
+					"dmg1": {
+						"type": "string"
+					},
+					"dmg2": {
+						"type": "string"
+					},
+					"dmgType": {
+						"type": "string"
+					},
+					"entries": {
+						"type": "array",
+						"items": {
+							"$ref": "/Entry"
+						}
+					},
+					"modifier": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"_category": {
+									"type": "string"
+								},
+								"__text": {
+									"type": "string"
+								},
+								"toString": {
+									"type": "array"
+								}
+							},
+							"required": [
+								"_category",
+								"__text",
+								"toString"
+							],
+							"additionalProperties": false
+						}
+					},
+					"property": {
+						"type": "string"
+					},
+					"range": {
+						"type": "string"
+					},
+					"reload": {
+						"type": "string"
+					},
+					"reqAttune": {
+						"type": "string"
+					},
+					"resist": {
+						"type": "string"
+					},
+					"scfType": {
+						"type": "string"
+					},
+					"speed": {
+						"type": "string"
+					},
+					"stealth": {
+						"type": "boolean"
+					},
+					"strength": {
+						"type": "string"
+					},
+					"sword": {
+						"type": "boolean"
+					},
+					"technology": {
+						"type": "string"
+					},
+					"tier": {
+						"type": "string"
+					},
+					"value": {
+						"type": "string"
+					},
+					"weapon": {
+						"type": "boolean"
+					},
+					"weaponCategory": {
+						"type": "string"
+					},
+					"weight": {
+						"type": "string"
+					},
+					"wondrous": {
+						"type": "boolean"
+					}
+				},
+				"required": [
+					"name",
+					"rarity",
+					"source",
+					"page"
+				],
+				"additionalProperties": false
+			}
+		}
+	},
+	"additionalProperties": false
+}


### PR DESCRIPTION
**data/basicitems.json**
Added all item properties and the item types that have boilerplate.

**data/items.json**
Aded `"armor"` Boolean for magical armor and fixed issues with hyperlink in Wand of Viscid Globs.

**data/magicvariants.json**
Changed `"type": "A"` to `"ammunition": true`.

**js/items.js**
Created property and type lookups from the JSON and used these to generate the boilerplate.
The renderable screen content is all stored within `"entries"`.

**js/utils.js**
Removed the propertyToAbv Parser function and associated constants (all superceded by JSON).

**test/schema/basicitems.json**
Added schema definitions for the item property and item type lookup JSON.