### PR TITLE
(feat) item categories and spell links

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -1088,7 +1088,7 @@
 			"page": "150",
 			"reqAttune": "YES",
 			"entries": [
-				"While wearing this amulet, you are hidden from divination magic. You can't be targeted by such magic or perceived through magical {@spell scrying|phb} sensors."
+				"While wearing this amulet, you are hidden from {@spell divination|phb} magic. You can't be targeted by such magic or perceived through magical {@spell scrying|phb} sensors."
 			]
 		},
 		{
@@ -1245,7 +1245,7 @@
 			"reqAttune": "YES",
 			"entries": [
 				"While wearing this armor, you have resistance to bludgeoning damage.",
-				"Curse. This armor is cursed, a fact that is revealed only when an identify spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by the {@spell remove curse|phb} spell or similar magic; removing the armor fails to end the curse. While cursed you have vulnerability to piercing and slashing damage."
+				"Curse. This armor is cursed, a fact that is revealed only when an {@spell identify|phb} spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by the {@spell remove curse|phb} spell or similar magic; removing the armor fails to end the curse. While cursed you have vulnerability to piercing and slashing damage."
 			]
 		},
 		{
@@ -1263,7 +1263,7 @@
 			"reqAttune": "YES",
 			"entries": [
 				"While wearing this armor, you have resistance to piercing damage.",
-				"Curse. This armor is cursed, a fact that is revealed only when an identify spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by the {@spell remove curse|phb} spell or similar magic; removing the armor fails to end the curse. While cursed you have vulnerability to bludgeoning and slashing damage."
+				"Curse. This armor is cursed, a fact that is revealed only when an {@spell identify|phb} spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by the {@spell remove curse|phb} spell or similar magic; removing the armor fails to end the curse. While cursed you have vulnerability to bludgeoning and slashing damage."
 			]
 		},
 		{
@@ -1281,7 +1281,7 @@
 			"reqAttune": "YES",
 			"entries": [
 				"While wearing this armor, you have resistance to slashing damage.",
-				"Curse. This armor is cursed, a fact that is revealed only when an identify spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by the {@spell remove curse|phb} spell or similar magic; removing the armor fails to end the curse. While cursed you have vulnerability to bludgeoning and piercing damage."
+				"Curse. This armor is cursed, a fact that is revealed only when an {@spell identify|phb} spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by the {@spell remove curse|phb} spell or similar magic; removing the armor fails to end the curse. While cursed you have vulnerability to bludgeoning and piercing damage."
 			]
 		},
 		{
@@ -3481,7 +3481,7 @@
 						[
 							"Ace of spades",
 							"Donjon*",
-							"You disappear and become entombed in a state of suspended animation in an extradimensional sphere. Everything you were wearing and carrying stays behind in the space you occupied when you disappeared. You remain imprisoned until you are found and removed from the sphere. You can't be located by any divination magic, but a {@spell wish|phb} spell can reveal the location of your prison. You draw no more cards."
+							"You disappear and become entombed in a state of suspended animation in an extradimensional sphere. Everything you were wearing and carrying stays behind in the space you occupied when you disappeared. You remain imprisoned until you are found and removed from the sphere. You can't be located by any {@spell divination|phb} magic, but a {@spell wish|phb} spell can reveal the location of your prison. You draw no more cards."
 						],
 						[
 							"King of spades",
@@ -3544,7 +3544,7 @@
 			"page": "222",
 			"entries": [
 				"A devastation orb is an elemental bomb that can be created at the site of an elemental node by performing a ritual with an elemental weapon. The type of orb created depends on the node used. For example, an air node creates a devastation orb of air. The ritual takes 1 hour to complete and requires 2,000 gp worth of special components, which are consumed.",
-				"A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as identify and divination can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.",
+				"A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as {@spell identify|phb} and {@spell divination|phb} can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.",
 				"A special container can be crafted to contain a devastation orb and prevent it from detonating. The container must be inscribed with symbols of the orb's opposing element. For example, a case inscribed with earth symbols can be used to contain a devastation orb of air and keep it from detonating. While in the container, the orb thrums. If it is removed from the container after the time when it was supposed to detonate, it explodes 1d6 rounds later, unless it is returned to the container.",
 				"Regardless of the type of orb, its effect is contained within a sphere with a 1 mile radius. The orb is the sphere's point of origin. The orb is destroyed after one use.",
 				"Air Orb. When this orb detonates, it creates a powerful windstorm that lasts for 1 hour. Whenever a creature ends its turn exposed to the wind, the creature must succeed on a DC 18 Constitution saving throw or take 1d4 bludgeoning damage, as the wind and debris batter it. The wind is strong enough to uproot weak trees and destroy light structures after at least 10 minutes of exposure. Otherwise, the rules for strong wind apply, as detailed in chapter 5 of the Dungeon Master's Guide."
@@ -3558,7 +3558,7 @@
 			"page": "222",
 			"entries": [
 				"A devastation orb is an elemental bomb that can be created at the site of an elemental node by performing a ritual with an elemental weapon. The type of orb created depends on the node used. For example, an air node creates a {@item devastation orb of air|PotA}. The ritual takes 1 hour to complete and requires 2,000 gp worth of special components, which are consumed.",
-				"A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as identify and divination can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.",
+				"A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as {@spell identify|phb} and {@spell divination|phb} can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.",
 				"A special container can be crafted to contain a devastation orb and prevent it from detonating. The container must be inscribed with symbols of the orb's opposing element. For example, a case inscribed with earth symbols can be used to contain a {@item devastation orb of air|PotA} and keep it from detonating. While in the container, the orb thrums. If it is removed from the container after the time when it was supposed to detonate, it explodes 1d6 rounds later, unless it is returned to the container.",
 				"Regardless of the type of orb, its effect is contained within a sphere with a 1 mile radius. The orb is the sphere's point of origin. The orb is destroyed after one use.",
 				"Earth Orb. When this orb detonates, it subjects the area to the effects of the {@spell earthquake|phb} spell for 1 minute (spell save DC 18). For the purpose of the spell's effects, the spell is cast on the turn that the orb explodes."
@@ -3572,7 +3572,7 @@
 			"page": "222",
 			"entries": [
 				"A devastation orb is an elemental bomb that can be created at the site of an elemental node by performing a ritual with an elemental weapon. The type of orb created depends on the node used. For example, an air node creates a {@item devastation orb of air|PotA}. The ritual takes 1 hour to complete and requires 2,000 gp worth of special components, which are consumed.",
-				"A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as identify and divination can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.",
+				"A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as {@spell identify|phb} and {@spell divination|phb} can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.",
 				"A special container can be crafted to contain a devastation orb and prevent it from detonating. The container must be inscribed with symbols of the orb's opposing element. For example, a case inscribed with earth symbols can be used to contain a {@item devastation orb of air|PotA} and keep it from detonating. While in the container, the orb thrums. If it is removed from the container after the time when it was supposed to detonate, it explodes 1d6 rounds later, unless it is returned to the container.",
 				"Regardless of the type of orb, its effect is contained within a sphere with a 1 mile radius. The orb is the sphere's point of origin. The orb is destroyed after one use.",
 				"Fire Orb. When this orb detonates, it creates a dry heat wave that lasts for 24 hours. Within the area of effect, the rules for extreme heat apply, as detailed in chapter 5 of the Dungeon Master's Guide. At the end of each hour, there is a ten percent chance that the heat wave starts a wildfire in a random location within the area of effect. The wildfire covers a 10-foot-square area initially but expands to fill another 10-foot square each round until the fire is extinguished or burns itself out. A creature that comes within 10 feet of a wildfire for the first time on a turn or starts its turn there takes 3d6 fire damage."
@@ -3809,7 +3809,7 @@
 			"source": "DMG",
 			"page": "166",
 			"entries": [
-				"Found in a small container, this powder resembles very fine sand. It appears to be {@item dust of disappearance|dmg}, and an identify spell reveals it to be such. There is enough of it for one use.",
+				"Found in a small container, this powder resembles very fine sand. It appears to be {@item dust of disappearance|dmg}, and an {@spell identify|phb} spell reveals it to be such. There is enough of it for one use.",
 				"When you use an action to throw a handful of the dust into the air, you and each creature that needs to breathe within 30 feet of you must succeed on a DC 15 Constitution saving throw or become unable to breathe while sneezing uncontrollably. A creature affected in this way is incapacitated and suffocating. As long as it is conscious, a creature can repeat the saving throw at the end of each of its turns, ending the effect on it on a success. The {@spell lesser restoration|phb} spell can also end the effect on a creature."
 			]
 		},
@@ -5465,7 +5465,7 @@
 			"entries": [
 				"This iron bottle has a brass stopper. You can use an action to speak the flask's command word, targeting a creature that you can see within 60 feet of you. If the target is native to a plane of existence other than the one you're on, the target must succeed on a DC 17 Wisdom saving throw or be trapped in the flask. If the target has been trapped by the flask before, it has advantage on the saving throw. Once trapped, a creature remains in the flask until released. The flask can hold only one creature at a time. A creature trapped in the flask doesn't need to breathe, eat, or drink and doesn't age.",
 				"You can use an action to remove the flask's stopper and release the creature the flask contains. The creature is friendly to you and your companions for 1 hour and obeys your commands for that duration. If you give no commands or give it a command that is likely to result in its death, it defends itself but otherwise takes no actions. At the end of the duration, the creature acts in accordance with its normal disposition and alignment.",
-				"An identify spell reveals that a creature is inside the flask, but the only way to determine the type of creature is to open the flask. A newly discovered bottle might already contain a creature chosen by the DM or determined randomly.",
+				"An {@spell identify|phb} spell reveals that a creature is inside the flask, but the only way to determine the type of creature is to open the flask. A newly discovered bottle might already contain a creature chosen by the DM or determined randomly.",
 				{
 					"type": "table",
 					"colLabels": [
@@ -7134,7 +7134,7 @@
 			"source": "DMG",
 			"page": "188",
 			"entries": [
-				"This concoction looks, smells, and tastes like a {@item potion of healing|dmg} or other beneficial potion. However, it is actually poison masked by illusion magic. An identify spell reveals its true nature.",
+				"This concoction looks, smells, and tastes like a {@item potion of healing|dmg} or other beneficial potion. However, it is actually poison masked by illusion magic. An {@spell identify|phb} spell reveals its true nature.",
 				"If you drink it, you take 3d6 poison damage, and you must succeed on a DC 13 Constitution saving throw or be poisoned. At the start of each of your turns while you are poisoned in this way, you take 3d6 poison damage. At the end of each of your turns, you can repeat the saving throw. On a successful save, the poison damage you take on your subsequent turns decreases by 1d6. The poison ends when the damage decreases to 0."
 			]
 		},
@@ -9246,7 +9246,7 @@
 			"reqAttune": "by a Druid, Sorcerer, Warlock, or Wizard",
 			"entries": [
 				"You have resistance to cold damage while you hold this staff.",
-				"The staff has 10 charges. While holding it, you can use an action to expend 1 or more of its charges to cast one of the following spells from it, using your spell save DC: {@spell cone of cold|phb} (5 charges), fog cloud (1 charge), {@spell ice storm|phb} (4 charges), or {@spell wall of ice|phb} (4 charges).",
+				"The staff has 10 charges. While holding it, you can use an action to expend 1 or more of its charges to cast one of the following spells from it, using your spell save DC: {@spell cone of cold|phb} (5 charges), {@spell fog cloud|phb} (1 charge), {@spell ice storm|phb} (4 charges), or {@spell wall of ice|phb} (4 charges).",
 				"The staff regains 1d6+4 expended charges daily at dawn. If you expend the last charge, roll a d20. On a 1. the staff turns to water and is destroyed."
 			]
 		},
@@ -9281,7 +9281,7 @@
 					"type": "entries",
 					"name": "Spells",
 					"entries": [
-						"While holding this staff, you can use an action to expend 1 or more of its charges to cast one of the following spells from it, using your spell save DC and spell attack bonus: {@spell cone of cold|phb} (5 charges), {@spell fireball|phb} (5th-level version, 5 charges), {@spell globe of invulnerability|phb} (6 charges), {@spell hold monster|phb} (5 charges), {@spell levitate|phb} (2 charges). {@spell lightning bolt|phb} (5th-level version, 5 charges), {@spell magic missile|phb} (1 charge), {@spells.html ray of enfeeblement|phb} (1 charge), or {@spell wall of force|phb} (5 charges)."
+						"While holding this staff, you can use an action to expend 1 or more of its charges to cast one of the following spells from it, using your spell save DC and spell attack bonus: {@spell cone of cold|phb} (5 charges), {@spell fireball|phb} (5th-level version, 5 charges), {@spell globe of invulnerability|phb} (6 charges), {@spell hold monster|phb} (5 charges), {@spell levitate|phb} (2 charges). {@spell lightning bolt|phb} (5th-level version, 5 charges), {@spell magic missile|phb} (1 charge), {@spell ray of enfeeblement|phb} (1 charge), or {@spell wall of force|phb} (5 charges)."
 					]
 				},
 				"Retributive Strike. You can use an action to break the staff over your knee or against a solid surface, performing a retributive strike. The staff is destroyed and releases its remaining magic in an explosion that expands to fill a 30-foot-radius sphere centered on it.",
@@ -9518,7 +9518,7 @@
 			"entries": [
 				"Created by the stone giant librarians of Gravenhollow, this nineteen-inch-long shard of quartz grants you advantage on Intelligence (investigation) checks while it is on your person.",
 				"The crystal has 10 charges. While holding it, you can use an action to expend some of its charges to cast one of the following spells from it: {@spell speak with animals|phb} (2 charges), {@spell speak with dead|phb} (4 charges), or {@spell speak with plants|phb} (3 charges).",
-				"When you cast a divination spell, you can use the crystal in place of one material component that would normally be consumed by the spell, at a cost of 1 charge per level of the spell. The crystal is not consumed when used in this way.",
+				"When you cast a {@spell divination|phb} spell, you can use the crystal in place of one material component that would normally be consumed by the spell, at a cost of 1 charge per level of the spell. The crystal is not consumed when used in this way.",
 				"The crystal regains 1d6+4 expended charges daily at dawn. If you expend the crystal's last charge, roll a d20. On a 1, the crystal vanishes, lost forever."
 			]
 		},
@@ -12350,7 +12350,7 @@
 			"page": "228",
 			"entries": [
 				"This stone is a large gem worth 150 gp.",
-				"Curse. The stone is cursed, but its magical nature is hidden; {@spell detect magic|phb} doesn't detect it. An identify spell reveals the stone's true nature. If you use the Dash or Disengage action while the stone is on your person, its curse activates. Until the curse is broken with {@spell remove curse|phb} or similar magic, your speed is reduced by 5 feet, and your maximum load and maximum lift capacities are halved. You also become unwilling to part with the stone."
+				"Curse. The stone is cursed, but its magical nature is hidden; {@spell detect magic|phb} doesn't detect it. An {@spell identify|phb} spell reveals the stone's true nature. If you use the Dash or Disengage action while the stone is on your person, its curse activates. Until the curse is broken with {@spell remove curse|phb} or similar magic, your speed is reduced by 5 feet, and your maximum load and maximum lift capacities are halved. You also become unwilling to part with the stone."
 			]
 		},
 		{
@@ -12490,7 +12490,7 @@
 			"page": "229",
 			"reqAttune": "YES",
 			"entries": [
-				"This polished agate appears to be a {@item stone of good luck|dmg} to anyone who tries to identify it, and it confers that item's property while on your person.",
+				"This polished agate appears to be a {@item stone of good luck|dmg} to anyone who tries to {@spell identify|phb} it, and it confers that item's property while on your person.",
 				"Curse. This item is cursed. While it is on your person, you take a -2 penalty to ability checks and saving throws. Until the curse is discovered, the DM secretly applies this penalty, assuming you are adding the item's bonus. You are unwilling to part with the stone until the curse is broken with {@spell remove curse|phb} or similar magic."
 			]
 		},
@@ -12666,12 +12666,12 @@
 				"{@creature Artus Cimber|ToA} has kept this item in his possession for over a century. The Ring of Winter is a golden band that resizes to fit snugly on the finger of its wearer. A thin layer of frost coats the outside of the ring, which normal heat can't melt. The ring feels ice cold to the touch and initially numbs the hand that wears it, but this cold ceases to be felt by one who is attuned to this ring.",
 				"The Ring of Winter is sentient and tries to take control of any creature that wears it (see \"Sentient Magic Items\" chapter 7 of the Dungeon Master's Guide). If it succeeds, the ring compels its wearer to cause undue harm to everyone and everything around it, in a cold-hearted attempt to incur the wrath of enemies and bring the wearer's doom.",
 				"Sentience. The Ring of Winter is a sentient chaotic evil item with an Intelligence of 14, a Wisdom of 14, and a Charisma of 17. The ring communicates by transmitting emotion to the creature carrying or wielding it, and it has hearing and normal vision out to a range of 60 feet. The ring craves destruction, and it likes inflicting indiscriminate harm on others.",
-				"Nondetection. The Ring of Winter defies attempts to magically locate it. Neither the ring nor its wearer can be targeted by any divination magic or perceived through magical {@spell scrying|phb} sensors.",
+				"Nondetection. The Ring of Winter defies attempts to magically locate it. Neither the ring nor its wearer can be targeted by any {@spell divination|phb} magic or perceived through magical {@spell scrying|phb} sensors.",
 				"Frozen Time. As long as you wear the ring, you don't age naturally. This effect is similar to suspended animation, in that your age doesn't catch up to you once the ring is removed. The ring doesn't protect its wearer from magical or supernatural aging effects, such as the Horrifying Visage of a {@creature ghost|mm}.",
 				"Cold Immunity. While attuned to and wearing the ring, you have immunity to cold damage and don't suffer any ill effects from extreme cold (see chapter 5 of the Dungeon's Master Guide).",
 				"Magic. The Ring of Winter has 12 charges and regains all its expended charges daily at dawn. While wearing the ring, you can expend the necessary number of charges to activate one of the following properties:",
 				"• You can expend 1 charge as an action and use the ring to lower the temperature in a 120-foot-radius sphere centered on a point you can see within 300 feet of you. The temperature in that area drops 20 degrees Per minute, to a minimum of -30 degrees Fahrenheit. Frost and ice begin to form on surfaces once the temperature drops below 32 degrees. This effect is permanent unless you use the ring to end it as an action, at which point the temperature in the area returns to normal at a rate of 10 degrees per minute.",
-				"• You can cast one of the following spells from the ring (spell save DC 17) by expending the necessary number of charges: {@spell bigby's hand|phb} (2 charges; the hand is made of ice, is immune to cold damage, and deals bludgeoning damage instead of force damage as a clenched fist), {@spell cone of cold|phb} (2 charges), flesh to ice (3 charges; as {@spell flesh to stone|phb} except that the target turns to solid ice with the density and durability of stone), {@spell ice storm|phb} (2 charges), {@spell otiluke's freezing sphere|phb} (3 charges), {@spell sleet storm|phb} (1 charge), {@spell spike growth|phb} (1 charge; the spikes are made of ice), or {@spell wall of ice|phb} (2 charges).",
+				"• You can cast one of the following spells from the ring (spell save DC 17) by expending the necessary number of charges: {@spell Bigby's hand|phb} (2 charges; the hand is made of ice, is immune to cold damage, and deals bludgeoning damage instead of force damage as a clenched fist), {@spell cone of cold|phb} (2 charges), flesh to ice (3 charges; as {@spell flesh to stone|phb} except that the target turns to solid ice with the density and durability of stone), {@spell ice storm|phb} (2 charges), {@spell Otiluke's freezing sphere|phb} (3 charges), {@spell sleet storm|phb} (1 charge), {@spell spike growth|phb} (1 charge; the spikes are made of ice), or {@spell wall of ice|phb} (2 charges).",
 				"• You can expend the necessary number of charges as an action and use the ring to create either an inanimate ice object (2 charges) or an animated ice creature (4 charges). The ice object can't have any moving parts, must be able to fit inside a 10-foot cube, and has the density and durability of metal or stone (your choice). The ice creature must be modeled after a beast with a challenge rating of 2 or less. The ice creature has the same statistics as the beast it models, with the following changes: the creature is a construct with vulnerability to fire damage, immunity to cold and poison damage, and immunity to the following conditions: charmed, exhaustion, frightened, paralyzed, petrified, and poisoned. The ice creature obeys only its creator's commands. The ice object or creature appears in an unoccupied space within 60 feet of you. It melts into a pool of normal water after 24 hours or when it drops to 0 hit points. In extreme heat, it loses 5 (1d10) hit points per minute as it melts. Use the guidelines in ch apter 8 of the Dungeon Master's Guide to determine the hit points of an inanimate object if they become necessary.",
 				"Other Properties. The Ring of Winter is rumored to possess other properties that can be activated only by an evil being whose will the ring can't break. Frost giants have long believed that the ring can be used to freeze entire worlds, while a {@creature djinni|mm} in the service of a Calishite pasha once claimed that the ring could be used to summon and control white dragons, as well as the mighty ice primordial named Cryonax.",
 				"Destroying the Ring. The ring is nigh indestructible, resisting even the most intense magical heat. If it is placed on the finger of the powerful archfey known as the Summer Queen, the ring melts away and is destroyed forever."
@@ -13088,7 +13088,7 @@
 			"page": "138",
 			"reqAttune": "YES",
 			"entries": [
-				"This musical instrument has 3 charges. While you are playing it, you can use an action to expend 1 charge from the instrument and write a magical message on a nonmagical object or surface that you can see within 30 feet of you. The message can be up to six words long and is written in a language you know. If you are a bard, you can scribe an additional seven words and choose to make the message glow faintly, allowing it to be seen in nonmagical darkness. Casting dispel magic on the message erases it. Otherwise, the message fades away after 24 hours.",
+				"This musical instrument has 3 charges. While you are playing it, you can use an action to expend 1 charge from the instrument and write a magical message on a nonmagical object or surface that you can see within 30 feet of you. The message can be up to six words long and is written in a language you know. If you are a bard, you can scribe an additional seven words and choose to make the message glow faintly, allowing it to be seen in nonmagical darkness. Casting {@spell dispel magic|phb} on the message erases it. Otherwise, the message fades away after 24 hours.",
 				"The instrument regains all expended charges daily at dawn."
 			]
 		},

--- a/data/items.json
+++ b/data/items.json
@@ -1088,7 +1088,7 @@
 			"page": "150",
 			"reqAttune": "YES",
 			"entries": [
-				"While wearing this amulet, you are hidden from {@spell divination|phb} magic. You can't be targeted by such magic or perceived through magical {@spell scrying|phb} sensors."
+				"While wearing this amulet, you are hidden from divination magic. You can't be targeted by such magic or perceived through magical {@spell scrying|phb} sensors."
 			]
 		},
 		{
@@ -1245,7 +1245,7 @@
 			"reqAttune": "YES",
 			"entries": [
 				"While wearing this armor, you have resistance to bludgeoning damage.",
-				"Curse. This armor is cursed, a fact that is revealed only when an {@spell identify|phb} spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by the {@spell remove curse|phb} spell or similar magic; removing the armor fails to end the curse. While cursed you have vulnerability to piercing and slashing damage."
+				"Curse. This armor is cursed, a fact that is revealed only when an identify spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by the {@spell remove curse|phb} spell or similar magic; removing the armor fails to end the curse. While cursed you have vulnerability to piercing and slashing damage."
 			]
 		},
 		{
@@ -1263,7 +1263,7 @@
 			"reqAttune": "YES",
 			"entries": [
 				"While wearing this armor, you have resistance to piercing damage.",
-				"Curse. This armor is cursed, a fact that is revealed only when an {@spell identify|phb} spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by the {@spell remove curse|phb} spell or similar magic; removing the armor fails to end the curse. While cursed you have vulnerability to bludgeoning and slashing damage."
+				"Curse. This armor is cursed, a fact that is revealed only when an identify spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by the {@spell remove curse|phb} spell or similar magic; removing the armor fails to end the curse. While cursed you have vulnerability to bludgeoning and slashing damage."
 			]
 		},
 		{
@@ -1281,7 +1281,7 @@
 			"reqAttune": "YES",
 			"entries": [
 				"While wearing this armor, you have resistance to slashing damage.",
-				"Curse. This armor is cursed, a fact that is revealed only when an {@spell identify|phb} spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by the {@spell remove curse|phb} spell or similar magic; removing the armor fails to end the curse. While cursed you have vulnerability to bludgeoning and piercing damage."
+				"Curse. This armor is cursed, a fact that is revealed only when an identify spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by the {@spell remove curse|phb} spell or similar magic; removing the armor fails to end the curse. While cursed you have vulnerability to bludgeoning and piercing damage."
 			]
 		},
 		{
@@ -3481,7 +3481,7 @@
 						[
 							"Ace of spades",
 							"Donjon*",
-							"You disappear and become entombed in a state of suspended animation in an extradimensional sphere. Everything you were wearing and carrying stays behind in the space you occupied when you disappeared. You remain imprisoned until you are found and removed from the sphere. You can't be located by any {@spell divination|phb} magic, but a {@spell wish|phb} spell can reveal the location of your prison. You draw no more cards."
+							"You disappear and become entombed in a state of suspended animation in an extradimensional sphere. Everything you were wearing and carrying stays behind in the space you occupied when you disappeared. You remain imprisoned until you are found and removed from the sphere. You can't be located by any divination magic, but a {@spell wish|phb} spell can reveal the location of your prison. You draw no more cards."
 						],
 						[
 							"King of spades",
@@ -3544,7 +3544,7 @@
 			"page": "222",
 			"entries": [
 				"A devastation orb is an elemental bomb that can be created at the site of an elemental node by performing a ritual with an elemental weapon. The type of orb created depends on the node used. For example, an air node creates a devastation orb of air. The ritual takes 1 hour to complete and requires 2,000 gp worth of special components, which are consumed.",
-				"A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as {@spell identify|phb} and {@spell divination|phb} can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.",
+				"A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as identify and divination can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.",
 				"A special container can be crafted to contain a devastation orb and prevent it from detonating. The container must be inscribed with symbols of the orb's opposing element. For example, a case inscribed with earth symbols can be used to contain a devastation orb of air and keep it from detonating. While in the container, the orb thrums. If it is removed from the container after the time when it was supposed to detonate, it explodes 1d6 rounds later, unless it is returned to the container.",
 				"Regardless of the type of orb, its effect is contained within a sphere with a 1 mile radius. The orb is the sphere's point of origin. The orb is destroyed after one use.",
 				"Air Orb. When this orb detonates, it creates a powerful windstorm that lasts for 1 hour. Whenever a creature ends its turn exposed to the wind, the creature must succeed on a DC 18 Constitution saving throw or take 1d4 bludgeoning damage, as the wind and debris batter it. The wind is strong enough to uproot weak trees and destroy light structures after at least 10 minutes of exposure. Otherwise, the rules for strong wind apply, as detailed in chapter 5 of the Dungeon Master's Guide."
@@ -3558,7 +3558,7 @@
 			"page": "222",
 			"entries": [
 				"A devastation orb is an elemental bomb that can be created at the site of an elemental node by performing a ritual with an elemental weapon. The type of orb created depends on the node used. For example, an air node creates a {@item devastation orb of air|PotA}. The ritual takes 1 hour to complete and requires 2,000 gp worth of special components, which are consumed.",
-				"A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as {@spell identify|phb} and {@spell divination|phb} can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.",
+				"A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as identify and divination can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.",
 				"A special container can be crafted to contain a devastation orb and prevent it from detonating. The container must be inscribed with symbols of the orb's opposing element. For example, a case inscribed with earth symbols can be used to contain a {@item devastation orb of air|PotA} and keep it from detonating. While in the container, the orb thrums. If it is removed from the container after the time when it was supposed to detonate, it explodes 1d6 rounds later, unless it is returned to the container.",
 				"Regardless of the type of orb, its effect is contained within a sphere with a 1 mile radius. The orb is the sphere's point of origin. The orb is destroyed after one use.",
 				"Earth Orb. When this orb detonates, it subjects the area to the effects of the {@spell earthquake|phb} spell for 1 minute (spell save DC 18). For the purpose of the spell's effects, the spell is cast on the turn that the orb explodes."
@@ -3572,7 +3572,7 @@
 			"page": "222",
 			"entries": [
 				"A devastation orb is an elemental bomb that can be created at the site of an elemental node by performing a ritual with an elemental weapon. The type of orb created depends on the node used. For example, an air node creates a {@item devastation orb of air|PotA}. The ritual takes 1 hour to complete and requires 2,000 gp worth of special components, which are consumed.",
-				"A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as {@spell identify|phb} and {@spell divination|phb} can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.",
+				"A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as identify and divination can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.",
 				"A special container can be crafted to contain a devastation orb and prevent it from detonating. The container must be inscribed with symbols of the orb's opposing element. For example, a case inscribed with earth symbols can be used to contain a {@item devastation orb of air|PotA} and keep it from detonating. While in the container, the orb thrums. If it is removed from the container after the time when it was supposed to detonate, it explodes 1d6 rounds later, unless it is returned to the container.",
 				"Regardless of the type of orb, its effect is contained within a sphere with a 1 mile radius. The orb is the sphere's point of origin. The orb is destroyed after one use.",
 				"Fire Orb. When this orb detonates, it creates a dry heat wave that lasts for 24 hours. Within the area of effect, the rules for extreme heat apply, as detailed in chapter 5 of the Dungeon Master's Guide. At the end of each hour, there is a ten percent chance that the heat wave starts a wildfire in a random location within the area of effect. The wildfire covers a 10-foot-square area initially but expands to fill another 10-foot square each round until the fire is extinguished or burns itself out. A creature that comes within 10 feet of a wildfire for the first time on a turn or starts its turn there takes 3d6 fire damage."
@@ -3809,7 +3809,7 @@
 			"source": "DMG",
 			"page": "166",
 			"entries": [
-				"Found in a small container, this powder resembles very fine sand. It appears to be {@item dust of disappearance|dmg}, and an {@spell identify|phb} spell reveals it to be such. There is enough of it for one use.",
+				"Found in a small container, this powder resembles very fine sand. It appears to be {@item dust of disappearance|dmg}, and an identify spell reveals it to be such. There is enough of it for one use.",
 				"When you use an action to throw a handful of the dust into the air, you and each creature that needs to breathe within 30 feet of you must succeed on a DC 15 Constitution saving throw or become unable to breathe while sneezing uncontrollably. A creature affected in this way is incapacitated and suffocating. As long as it is conscious, a creature can repeat the saving throw at the end of each of its turns, ending the effect on it on a success. The {@spell lesser restoration|phb} spell can also end the effect on a creature."
 			]
 		},
@@ -5465,7 +5465,7 @@
 			"entries": [
 				"This iron bottle has a brass stopper. You can use an action to speak the flask's command word, targeting a creature that you can see within 60 feet of you. If the target is native to a plane of existence other than the one you're on, the target must succeed on a DC 17 Wisdom saving throw or be trapped in the flask. If the target has been trapped by the flask before, it has advantage on the saving throw. Once trapped, a creature remains in the flask until released. The flask can hold only one creature at a time. A creature trapped in the flask doesn't need to breathe, eat, or drink and doesn't age.",
 				"You can use an action to remove the flask's stopper and release the creature the flask contains. The creature is friendly to you and your companions for 1 hour and obeys your commands for that duration. If you give no commands or give it a command that is likely to result in its death, it defends itself but otherwise takes no actions. At the end of the duration, the creature acts in accordance with its normal disposition and alignment.",
-				"An {@spell identify|phb} spell reveals that a creature is inside the flask, but the only way to determine the type of creature is to open the flask. A newly discovered bottle might already contain a creature chosen by the DM or determined randomly.",
+				"An identify spell reveals that a creature is inside the flask, but the only way to determine the type of creature is to open the flask. A newly discovered bottle might already contain a creature chosen by the DM or determined randomly.",
 				{
 					"type": "table",
 					"colLabels": [
@@ -7134,7 +7134,7 @@
 			"source": "DMG",
 			"page": "188",
 			"entries": [
-				"This concoction looks, smells, and tastes like a {@item potion of healing|dmg} or other beneficial potion. However, it is actually poison masked by illusion magic. An {@spell identify|phb} spell reveals its true nature.",
+				"This concoction looks, smells, and tastes like a {@item potion of healing|dmg} or other beneficial potion. However, it is actually poison masked by illusion magic. An identify spell reveals its true nature.",
 				"If you drink it, you take 3d6 poison damage, and you must succeed on a DC 13 Constitution saving throw or be poisoned. At the start of each of your turns while you are poisoned in this way, you take 3d6 poison damage. At the end of each of your turns, you can repeat the saving throw. On a successful save, the poison damage you take on your subsequent turns decreases by 1d6. The poison ends when the damage decreases to 0."
 			]
 		},
@@ -9246,7 +9246,7 @@
 			"reqAttune": "by a Druid, Sorcerer, Warlock, or Wizard",
 			"entries": [
 				"You have resistance to cold damage while you hold this staff.",
-				"The staff has 10 charges. While holding it, you can use an action to expend 1 or more of its charges to cast one of the following spells from it, using your spell save DC: {@spell cone of cold|phb} (5 charges), {@spell fog cloud|phb} (1 charge), {@spell ice storm|phb} (4 charges), or {@spell wall of ice|phb} (4 charges).",
+				"The staff has 10 charges. While holding it, you can use an action to expend 1 or more of its charges to cast one of the following spells from it, using your spell save DC: {@spell cone of cold|phb} (5 charges), fog cloud (1 charge), {@spell ice storm|phb} (4 charges), or {@spell wall of ice|phb} (4 charges).",
 				"The staff regains 1d6+4 expended charges daily at dawn. If you expend the last charge, roll a d20. On a 1. the staff turns to water and is destroyed."
 			]
 		},
@@ -9281,7 +9281,7 @@
 					"type": "entries",
 					"name": "Spells",
 					"entries": [
-						"While holding this staff, you can use an action to expend 1 or more of its charges to cast one of the following spells from it, using your spell save DC and spell attack bonus: {@spell cone of cold|phb} (5 charges), {@spell fireball|phb} (5th-level version, 5 charges), {@spell globe of invulnerability|phb} (6 charges), {@spell hold monster|phb} (5 charges), {@spell levitate|phb} (2 charges). {@spell lightning bolt|phb} (5th-level version, 5 charges), {@spell magic missile|phb} (1 charge), {@spell ray of enfeeblement|phb} (1 charge), or {@spell wall of force|phb} (5 charges)."
+						"While holding this staff, you can use an action to expend 1 or more of its charges to cast one of the following spells from it, using your spell save DC and spell attack bonus: {@spell cone of cold|phb} (5 charges), {@spell fireball|phb} (5th-level version, 5 charges), {@spell globe of invulnerability|phb} (6 charges), {@spell hold monster|phb} (5 charges), {@spell levitate|phb} (2 charges). {@spell lightning bolt|phb} (5th-level version, 5 charges), {@spell magic missile|phb} (1 charge), {@spells.html ray of enfeeblement|phb} (1 charge), or {@spell wall of force|phb} (5 charges)."
 					]
 				},
 				"Retributive Strike. You can use an action to break the staff over your knee or against a solid surface, performing a retributive strike. The staff is destroyed and releases its remaining magic in an explosion that expands to fill a 30-foot-radius sphere centered on it.",
@@ -9518,7 +9518,7 @@
 			"entries": [
 				"Created by the stone giant librarians of Gravenhollow, this nineteen-inch-long shard of quartz grants you advantage on Intelligence (investigation) checks while it is on your person.",
 				"The crystal has 10 charges. While holding it, you can use an action to expend some of its charges to cast one of the following spells from it: {@spell speak with animals|phb} (2 charges), {@spell speak with dead|phb} (4 charges), or {@spell speak with plants|phb} (3 charges).",
-				"When you cast a {@spell divination|phb} spell, you can use the crystal in place of one material component that would normally be consumed by the spell, at a cost of 1 charge per level of the spell. The crystal is not consumed when used in this way.",
+				"When you cast a divination spell, you can use the crystal in place of one material component that would normally be consumed by the spell, at a cost of 1 charge per level of the spell. The crystal is not consumed when used in this way.",
 				"The crystal regains 1d6+4 expended charges daily at dawn. If you expend the crystal's last charge, roll a d20. On a 1, the crystal vanishes, lost forever."
 			]
 		},
@@ -12350,7 +12350,7 @@
 			"page": "228",
 			"entries": [
 				"This stone is a large gem worth 150 gp.",
-				"Curse. The stone is cursed, but its magical nature is hidden; {@spell detect magic|phb} doesn't detect it. An {@spell identify|phb} spell reveals the stone's true nature. If you use the Dash or Disengage action while the stone is on your person, its curse activates. Until the curse is broken with {@spell remove curse|phb} or similar magic, your speed is reduced by 5 feet, and your maximum load and maximum lift capacities are halved. You also become unwilling to part with the stone."
+				"Curse. The stone is cursed, but its magical nature is hidden; {@spell detect magic|phb} doesn't detect it. An identify spell reveals the stone's true nature. If you use the Dash or Disengage action while the stone is on your person, its curse activates. Until the curse is broken with {@spell remove curse|phb} or similar magic, your speed is reduced by 5 feet, and your maximum load and maximum lift capacities are halved. You also become unwilling to part with the stone."
 			]
 		},
 		{
@@ -12490,7 +12490,7 @@
 			"page": "229",
 			"reqAttune": "YES",
 			"entries": [
-				"This polished agate appears to be a {@item stone of good luck|dmg} to anyone who tries to {@spell identify|phb} it, and it confers that item's property while on your person.",
+				"This polished agate appears to be a {@item stone of good luck|dmg} to anyone who tries to identify it, and it confers that item's property while on your person.",
 				"Curse. This item is cursed. While it is on your person, you take a -2 penalty to ability checks and saving throws. Until the curse is discovered, the DM secretly applies this penalty, assuming you are adding the item's bonus. You are unwilling to part with the stone until the curse is broken with {@spell remove curse|phb} or similar magic."
 			]
 		},
@@ -12666,12 +12666,12 @@
 				"{@creature Artus Cimber|ToA} has kept this item in his possession for over a century. The Ring of Winter is a golden band that resizes to fit snugly on the finger of its wearer. A thin layer of frost coats the outside of the ring, which normal heat can't melt. The ring feels ice cold to the touch and initially numbs the hand that wears it, but this cold ceases to be felt by one who is attuned to this ring.",
 				"The Ring of Winter is sentient and tries to take control of any creature that wears it (see \"Sentient Magic Items\" chapter 7 of the Dungeon Master's Guide). If it succeeds, the ring compels its wearer to cause undue harm to everyone and everything around it, in a cold-hearted attempt to incur the wrath of enemies and bring the wearer's doom.",
 				"Sentience. The Ring of Winter is a sentient chaotic evil item with an Intelligence of 14, a Wisdom of 14, and a Charisma of 17. The ring communicates by transmitting emotion to the creature carrying or wielding it, and it has hearing and normal vision out to a range of 60 feet. The ring craves destruction, and it likes inflicting indiscriminate harm on others.",
-				"Nondetection. The Ring of Winter defies attempts to magically locate it. Neither the ring nor its wearer can be targeted by any {@spell divination|phb} magic or perceived through magical {@spell scrying|phb} sensors.",
+				"Nondetection. The Ring of Winter defies attempts to magically locate it. Neither the ring nor its wearer can be targeted by any divination magic or perceived through magical {@spell scrying|phb} sensors.",
 				"Frozen Time. As long as you wear the ring, you don't age naturally. This effect is similar to suspended animation, in that your age doesn't catch up to you once the ring is removed. The ring doesn't protect its wearer from magical or supernatural aging effects, such as the Horrifying Visage of a {@creature ghost|mm}.",
 				"Cold Immunity. While attuned to and wearing the ring, you have immunity to cold damage and don't suffer any ill effects from extreme cold (see chapter 5 of the Dungeon's Master Guide).",
 				"Magic. The Ring of Winter has 12 charges and regains all its expended charges daily at dawn. While wearing the ring, you can expend the necessary number of charges to activate one of the following properties:",
 				"• You can expend 1 charge as an action and use the ring to lower the temperature in a 120-foot-radius sphere centered on a point you can see within 300 feet of you. The temperature in that area drops 20 degrees Per minute, to a minimum of -30 degrees Fahrenheit. Frost and ice begin to form on surfaces once the temperature drops below 32 degrees. This effect is permanent unless you use the ring to end it as an action, at which point the temperature in the area returns to normal at a rate of 10 degrees per minute.",
-				"• You can cast one of the following spells from the ring (spell save DC 17) by expending the necessary number of charges: {@spell Bigby's hand|phb} (2 charges; the hand is made of ice, is immune to cold damage, and deals bludgeoning damage instead of force damage as a clenched fist), {@spell cone of cold|phb} (2 charges), flesh to ice (3 charges; as {@spell flesh to stone|phb} except that the target turns to solid ice with the density and durability of stone), {@spell ice storm|phb} (2 charges), {@spell Otiluke's freezing sphere|phb} (3 charges), {@spell sleet storm|phb} (1 charge), {@spell spike growth|phb} (1 charge; the spikes are made of ice), or {@spell wall of ice|phb} (2 charges).",
+				"• You can cast one of the following spells from the ring (spell save DC 17) by expending the necessary number of charges: {@spell bigby's hand|phb} (2 charges; the hand is made of ice, is immune to cold damage, and deals bludgeoning damage instead of force damage as a clenched fist), {@spell cone of cold|phb} (2 charges), flesh to ice (3 charges; as {@spell flesh to stone|phb} except that the target turns to solid ice with the density and durability of stone), {@spell ice storm|phb} (2 charges), {@spell otiluke's freezing sphere|phb} (3 charges), {@spell sleet storm|phb} (1 charge), {@spell spike growth|phb} (1 charge; the spikes are made of ice), or {@spell wall of ice|phb} (2 charges).",
 				"• You can expend the necessary number of charges as an action and use the ring to create either an inanimate ice object (2 charges) or an animated ice creature (4 charges). The ice object can't have any moving parts, must be able to fit inside a 10-foot cube, and has the density and durability of metal or stone (your choice). The ice creature must be modeled after a beast with a challenge rating of 2 or less. The ice creature has the same statistics as the beast it models, with the following changes: the creature is a construct with vulnerability to fire damage, immunity to cold and poison damage, and immunity to the following conditions: charmed, exhaustion, frightened, paralyzed, petrified, and poisoned. The ice creature obeys only its creator's commands. The ice object or creature appears in an unoccupied space within 60 feet of you. It melts into a pool of normal water after 24 hours or when it drops to 0 hit points. In extreme heat, it loses 5 (1d10) hit points per minute as it melts. Use the guidelines in ch apter 8 of the Dungeon Master's Guide to determine the hit points of an inanimate object if they become necessary.",
 				"Other Properties. The Ring of Winter is rumored to possess other properties that can be activated only by an evil being whose will the ring can't break. Frost giants have long believed that the ring can be used to freeze entire worlds, while a {@creature djinni|mm} in the service of a Calishite pasha once claimed that the ring could be used to summon and control white dragons, as well as the mighty ice primordial named Cryonax.",
 				"Destroying the Ring. The ring is nigh indestructible, resisting even the most intense magical heat. If it is placed on the finger of the powerful archfey known as the Summer Queen, the ring melts away and is destroyed forever."
@@ -13088,7 +13088,7 @@
 			"page": "138",
 			"reqAttune": "YES",
 			"entries": [
-				"This musical instrument has 3 charges. While you are playing it, you can use an action to expend 1 charge from the instrument and write a magical message on a nonmagical object or surface that you can see within 30 feet of you. The message can be up to six words long and is written in a language you know. If you are a bard, you can scribe an additional seven words and choose to make the message glow faintly, allowing it to be seen in nonmagical darkness. Casting {@spell dispel magic|phb} on the message erases it. Otherwise, the message fades away after 24 hours.",
+				"This musical instrument has 3 charges. While you are playing it, you can use an action to expend 1 charge from the instrument and write a magical message on a nonmagical object or surface that you can see within 30 feet of you. The message can be up to six words long and is written in a language you know. If you are a bard, you can scribe an additional seven words and choose to make the message glow faintly, allowing it to be seen in nonmagical darkness. Casting dispel magic on the message erases it. Otherwise, the message fades away after 24 hours.",
 				"The instrument regains all expended charges daily at dawn."
 			]
 		},

--- a/data/magicvariants.json
+++ b/data/magicvariants.json
@@ -2,7 +2,7 @@
 	"variant": [
 		{
 			"name": "Armor +1",
-			"type": "MV",
+			"type": "GV",
 			"entries": [
 				"You have a +1 bonus to AC while wearing this armor."
 			],
@@ -32,7 +32,7 @@
 		},
 		{
 			"name": "Armor +2",
-			"type": "MV",
+			"type": "GV",
 			"entries": [
 				"You have a +2 bonus to AC while wearing this armor."
 			],
@@ -62,7 +62,7 @@
 		},
 		{
 			"name": "Armor +3",
-			"type": "MV",
+			"type": "GV",
 			"entries": [
 				"You have a +3 bonus to AC while wearing this armor."
 			],
@@ -92,7 +92,7 @@
 		},
 		{
 			"name": "Shield +1",
-			"type": "MV",
+			"type": "GV",
 			"entries": [
 				"While holding this shield, you have a +1 bonus to AC. This bonus is in addition to the shield's normal bonus to AC."
 			],
@@ -122,7 +122,7 @@
 		},
 		{
 			"name": "Shield +2",
-			"type": "MV",
+			"type": "GV",
 			"entries": [
 				"While holding this shield, you have a +2 bonus to AC. This bonus is in addition to the shield's normal bonus to AC."
 			],
@@ -152,7 +152,7 @@
 		},
 		{
 			"name": "Shield +3",
-			"type": "MV",
+			"type": "GV",
 			"entries": [
 				"While holding this shield, you have a +3 bonus to AC. This bonus is in addition to the shield's normal bonus to AC."
 			],
@@ -182,7 +182,7 @@
 		},
 		{
 			"name": "Armor of Gleaming",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"armor": true
 			},
@@ -199,7 +199,7 @@
 		},
 		{
 			"name": "Armor of Acid Resistance",
-			"type": "MV",
+			"type": "GV",
 			"resist": "acid",
 			"requires": {
 				"armor": true
@@ -216,7 +216,7 @@
 		},
 		{
 			"name": "Armor of Cold Resistance",
-			"type": "MV",
+			"type": "GV",
 			"resist": "cold",
 			"requires": {
 				"armor": true
@@ -233,7 +233,7 @@
 		},
 		{
 			"name": "Armor of Fire Resistance",
-			"type": "MV",
+			"type": "GV",
 			"resist": "fire",
 			"requires": {
 				"armor": true
@@ -250,7 +250,7 @@
 		},
 		{
 			"name": "Armor of Force Resistance",
-			"type": "MV",
+			"type": "GV",
 			"resist": "force",
 			"requires": {
 				"armor": true
@@ -267,7 +267,7 @@
 		},
 		{
 			"name": "Armor of Lightning Resistance",
-			"type": "MV",
+			"type": "GV",
 			"resist": "lightning",
 			"requires": {
 				"armor": true
@@ -284,7 +284,7 @@
 		},
 		{
 			"name": "Armor of Necrotic Resistance",
-			"type": "MV",
+			"type": "GV",
 			"resist": "necrotic",
 			"requires": {
 				"armor": true
@@ -301,7 +301,7 @@
 		},
 		{
 			"name": "Armor of Poison Resistance",
-			"type": "MV",
+			"type": "GV",
 			"resist": "poison",
 			"requires": {
 				"armor": true
@@ -318,7 +318,7 @@
 		},
 		{
 			"name": "Armor of Psychic Resistance",
-			"type": "MV",
+			"type": "GV",
 			"resist": "psychic",
 			"requires": {
 				"armor": true
@@ -335,7 +335,7 @@
 		},
 		{
 			"name": "Armor of Radiant Resistance",
-			"type": "MV",
+			"type": "GV",
 			"resist": "radiant",
 			"requires": {
 				"armor": true
@@ -352,7 +352,7 @@
 		},
 		{
 			"name": "Armor of Thunder Resistance",
-			"type": "MV",
+			"type": "GV",
 			"resist": "thunder",
 			"requires": {
 				"armor": true
@@ -369,7 +369,7 @@
 		},
 		{
 			"name": "Adamantine Armor",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"type": "HA"
 			},
@@ -408,7 +408,7 @@
 		},
 		{
 			"name": "Cast-Off Armor",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"armor": true
 			},
@@ -425,7 +425,7 @@
 		},
 		{
 			"name": "Mariner's Armor",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"armor": true
 			},
@@ -442,7 +442,7 @@
 		},
 		{
 			"name": "Mind Carapace Armor",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"type": "HA"
 			},
@@ -459,7 +459,7 @@
 		},
 		{
 			"name": "Mithral Armor",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"type": "HA"
 			},
@@ -500,7 +500,7 @@
 		},
 		{
 			"name": "Moon—Touched Sword",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"sword": true
 			},
@@ -517,7 +517,7 @@
 		},
 		{
 			"name": "Smoldering Armor",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"armor": true
 			},
@@ -534,7 +534,7 @@
 		},
 		{
 			"name": "Ammunition +1",
-			"type": "MV",
+			"type": "GV",
 			"entries": [
 				"You have a +1 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical."
 			],
@@ -571,7 +571,7 @@
 		},
 		{
 			"name": "Ammunition +2",
-			"type": "MV",
+			"type": "GV",
 			"entries": [
 				"You have a +2 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical."
 			],
@@ -608,7 +608,7 @@
 		},
 		{
 			"name": "Ammunition +3",
-			"type": "MV",
+			"type": "GV",
 			"entries": [
 				"You have a +3 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical."
 			],
@@ -645,7 +645,7 @@
 		},
 		{
 			"name": "Walloping Ammunition",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"ammunition": true
 			},
@@ -662,7 +662,7 @@
 		},
 		{
 			"name": "Weapon (no damage) +1",
-			"type": "MV",
+			"type": "GV",
 			"entries": [
 				"You have a +1 bonus to attack rolls made with this weapon."
 			],
@@ -683,7 +683,7 @@
 		},
 		{
 			"name": "Weapon (no damage) +2",
-			"type": "MV",
+			"type": "GV",
 			"entries": [
 				"You have a +2 bonus to attack rolls made with this weapon."
 			],
@@ -704,7 +704,7 @@
 		},
 		{
 			"name": "Weapon (no damage) +3",
-			"type": "MV",
+			"type": "GV",
 			"entries": [
 				"You have a +3 bonus to attack rolls made with this weapon."
 			],
@@ -725,7 +725,7 @@
 		},
 		{
 			"name": "Weapon +1",
-			"type": "MV",
+			"type": "GV",
 			"entries": [
 				"You have a +1 bonus to attack and damage rolls made with this weapon."
 			],
@@ -749,7 +749,7 @@
 		},
 		{
 			"name": "Weapon +2",
-			"type": "MV",
+			"type": "GV",
 			"entries": [
 				"You have a +2 bonus to attack and damage rolls made with this weapon."
 			],
@@ -773,7 +773,7 @@
 		},
 		{
 			"name": "Weapon +3",
-			"type": "MV",
+			"type": "GV",
 			"entries": [
 				"You have a +3 bonus to attack and damage rolls made with this weapon."
 			],
@@ -797,7 +797,7 @@
 		},
 		{
 			"name": "Weapon of Warning",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"weapon": true
 			},
@@ -814,7 +814,7 @@
 		},
 		{
 			"name": "Berserker Axe",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"axe": true
 			},
@@ -850,7 +850,7 @@
 		},
 		{
 			"name": "Dancing Sword",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"sword": true
 			},
@@ -870,7 +870,7 @@
 		},
 		{
 			"name": "Defender",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"sword": true
 			},
@@ -889,7 +889,7 @@
 		},
 		{
 			"name": "Dragon Slayer",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"sword": true
 			},
@@ -923,7 +923,7 @@
 		},
 		{
 			"name": "Flame Tongue",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"sword": true
 			},
@@ -941,7 +941,7 @@
 		},
 		{
 			"name": "Frost Brand",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"sword": true
 			},
@@ -961,7 +961,7 @@
 		},
 		{
 			"name": "Giant Slayer",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"axe": true
 			},
@@ -1031,7 +1031,7 @@
 		},
 		{
 			"name": "Holy Avenger",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"sword": true
 			},
@@ -1066,7 +1066,7 @@
 		},
 		{
 			"name": "Luck Blade",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"sword": true
 			},
@@ -1109,7 +1109,7 @@
 		},
 		{
 			"name": "Mind Blade",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"sword": true
 			},
@@ -1126,7 +1126,7 @@
 		},
 		{
 			"name": "Nine Lives Stealer",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"sword": true
 			},
@@ -1161,7 +1161,7 @@
 		},
 		{
 			"name": "Sword of Life Stealing",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"sword": true
 			},
@@ -1179,7 +1179,7 @@
 		},
 		{
 			"name": "Sword of Sharpness",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"sword": true,
 				"dmgType": "S"
@@ -1200,7 +1200,7 @@
 		},
 		{
 			"name": "Sword of Vengeance",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"sword": true
 			},
@@ -1237,7 +1237,7 @@
 		},
 		{
 			"name": "Sword of Wounding",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"sword": true
 			},
@@ -1256,7 +1256,7 @@
 		},
 		{
 			"name": "Vicious Weapon",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"weapon": true
 			},
@@ -1277,7 +1277,7 @@
 		},
 		{
 			"name": "Vorpal Sword",
-			"type": "MV",
+			"type": "GV",
 			"requires": {
 				"sword": true,
 				"dmgType": "S"

--- a/data/magicvariants.json
+++ b/data/magicvariants.json
@@ -2,7 +2,7 @@
 	"variant": [
 		{
 			"name": "Armor +1",
-			"type": "GV",
+			"type": "MV",
 			"entries": [
 				"You have a +1 bonus to AC while wearing this armor."
 			],
@@ -32,7 +32,7 @@
 		},
 		{
 			"name": "Armor +2",
-			"type": "GV",
+			"type": "MV",
 			"entries": [
 				"You have a +2 bonus to AC while wearing this armor."
 			],
@@ -62,7 +62,7 @@
 		},
 		{
 			"name": "Armor +3",
-			"type": "GV",
+			"type": "MV",
 			"entries": [
 				"You have a +3 bonus to AC while wearing this armor."
 			],
@@ -92,7 +92,7 @@
 		},
 		{
 			"name": "Shield +1",
-			"type": "GV",
+			"type": "MV",
 			"entries": [
 				"While holding this shield, you have a +1 bonus to AC. This bonus is in addition to the shield's normal bonus to AC."
 			],
@@ -122,7 +122,7 @@
 		},
 		{
 			"name": "Shield +2",
-			"type": "GV",
+			"type": "MV",
 			"entries": [
 				"While holding this shield, you have a +2 bonus to AC. This bonus is in addition to the shield's normal bonus to AC."
 			],
@@ -152,7 +152,7 @@
 		},
 		{
 			"name": "Shield +3",
-			"type": "GV",
+			"type": "MV",
 			"entries": [
 				"While holding this shield, you have a +3 bonus to AC. This bonus is in addition to the shield's normal bonus to AC."
 			],
@@ -182,7 +182,7 @@
 		},
 		{
 			"name": "Armor of Gleaming",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"armor": true
 			},
@@ -199,7 +199,7 @@
 		},
 		{
 			"name": "Armor of Acid Resistance",
-			"type": "GV",
+			"type": "MV",
 			"resist": "acid",
 			"requires": {
 				"armor": true
@@ -216,7 +216,7 @@
 		},
 		{
 			"name": "Armor of Cold Resistance",
-			"type": "GV",
+			"type": "MV",
 			"resist": "cold",
 			"requires": {
 				"armor": true
@@ -233,7 +233,7 @@
 		},
 		{
 			"name": "Armor of Fire Resistance",
-			"type": "GV",
+			"type": "MV",
 			"resist": "fire",
 			"requires": {
 				"armor": true
@@ -250,7 +250,7 @@
 		},
 		{
 			"name": "Armor of Force Resistance",
-			"type": "GV",
+			"type": "MV",
 			"resist": "force",
 			"requires": {
 				"armor": true
@@ -267,7 +267,7 @@
 		},
 		{
 			"name": "Armor of Lightning Resistance",
-			"type": "GV",
+			"type": "MV",
 			"resist": "lightning",
 			"requires": {
 				"armor": true
@@ -284,7 +284,7 @@
 		},
 		{
 			"name": "Armor of Necrotic Resistance",
-			"type": "GV",
+			"type": "MV",
 			"resist": "necrotic",
 			"requires": {
 				"armor": true
@@ -301,7 +301,7 @@
 		},
 		{
 			"name": "Armor of Poison Resistance",
-			"type": "GV",
+			"type": "MV",
 			"resist": "poison",
 			"requires": {
 				"armor": true
@@ -318,7 +318,7 @@
 		},
 		{
 			"name": "Armor of Psychic Resistance",
-			"type": "GV",
+			"type": "MV",
 			"resist": "psychic",
 			"requires": {
 				"armor": true
@@ -335,7 +335,7 @@
 		},
 		{
 			"name": "Armor of Radiant Resistance",
-			"type": "GV",
+			"type": "MV",
 			"resist": "radiant",
 			"requires": {
 				"armor": true
@@ -352,7 +352,7 @@
 		},
 		{
 			"name": "Armor of Thunder Resistance",
-			"type": "GV",
+			"type": "MV",
 			"resist": "thunder",
 			"requires": {
 				"armor": true
@@ -369,7 +369,7 @@
 		},
 		{
 			"name": "Adamantine Armor",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"type": "HA"
 			},
@@ -408,7 +408,7 @@
 		},
 		{
 			"name": "Cast-Off Armor",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"armor": true
 			},
@@ -425,7 +425,7 @@
 		},
 		{
 			"name": "Mariner's Armor",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"armor": true
 			},
@@ -442,7 +442,7 @@
 		},
 		{
 			"name": "Mind Carapace Armor",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"type": "HA"
 			},
@@ -459,7 +459,7 @@
 		},
 		{
 			"name": "Mithral Armor",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"type": "HA"
 			},
@@ -500,7 +500,7 @@
 		},
 		{
 			"name": "Moon—Touched Sword",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"sword": true
 			},
@@ -517,7 +517,7 @@
 		},
 		{
 			"name": "Smoldering Armor",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"armor": true
 			},
@@ -534,7 +534,7 @@
 		},
 		{
 			"name": "Ammunition +1",
-			"type": "GV",
+			"type": "MV",
 			"entries": [
 				"You have a +1 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical."
 			],
@@ -571,7 +571,7 @@
 		},
 		{
 			"name": "Ammunition +2",
-			"type": "GV",
+			"type": "MV",
 			"entries": [
 				"You have a +2 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical."
 			],
@@ -608,7 +608,7 @@
 		},
 		{
 			"name": "Ammunition +3",
-			"type": "GV",
+			"type": "MV",
 			"entries": [
 				"You have a +3 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical."
 			],
@@ -645,7 +645,7 @@
 		},
 		{
 			"name": "Walloping Ammunition",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"ammunition": true
 			},
@@ -662,7 +662,7 @@
 		},
 		{
 			"name": "Weapon (no damage) +1",
-			"type": "GV",
+			"type": "MV",
 			"entries": [
 				"You have a +1 bonus to attack rolls made with this weapon."
 			],
@@ -683,7 +683,7 @@
 		},
 		{
 			"name": "Weapon (no damage) +2",
-			"type": "GV",
+			"type": "MV",
 			"entries": [
 				"You have a +2 bonus to attack rolls made with this weapon."
 			],
@@ -704,7 +704,7 @@
 		},
 		{
 			"name": "Weapon (no damage) +3",
-			"type": "GV",
+			"type": "MV",
 			"entries": [
 				"You have a +3 bonus to attack rolls made with this weapon."
 			],
@@ -725,7 +725,7 @@
 		},
 		{
 			"name": "Weapon +1",
-			"type": "GV",
+			"type": "MV",
 			"entries": [
 				"You have a +1 bonus to attack and damage rolls made with this weapon."
 			],
@@ -749,7 +749,7 @@
 		},
 		{
 			"name": "Weapon +2",
-			"type": "GV",
+			"type": "MV",
 			"entries": [
 				"You have a +2 bonus to attack and damage rolls made with this weapon."
 			],
@@ -773,7 +773,7 @@
 		},
 		{
 			"name": "Weapon +3",
-			"type": "GV",
+			"type": "MV",
 			"entries": [
 				"You have a +3 bonus to attack and damage rolls made with this weapon."
 			],
@@ -797,7 +797,7 @@
 		},
 		{
 			"name": "Weapon of Warning",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"weapon": true
 			},
@@ -814,7 +814,7 @@
 		},
 		{
 			"name": "Berserker Axe",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"axe": true
 			},
@@ -850,7 +850,7 @@
 		},
 		{
 			"name": "Dancing Sword",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"sword": true
 			},
@@ -870,7 +870,7 @@
 		},
 		{
 			"name": "Defender",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"sword": true
 			},
@@ -889,7 +889,7 @@
 		},
 		{
 			"name": "Dragon Slayer",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"sword": true
 			},
@@ -923,7 +923,7 @@
 		},
 		{
 			"name": "Flame Tongue",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"sword": true
 			},
@@ -941,7 +941,7 @@
 		},
 		{
 			"name": "Frost Brand",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"sword": true
 			},
@@ -961,7 +961,7 @@
 		},
 		{
 			"name": "Giant Slayer",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"axe": true
 			},
@@ -1031,7 +1031,7 @@
 		},
 		{
 			"name": "Holy Avenger",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"sword": true
 			},
@@ -1066,7 +1066,7 @@
 		},
 		{
 			"name": "Luck Blade",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"sword": true
 			},
@@ -1109,7 +1109,7 @@
 		},
 		{
 			"name": "Mind Blade",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"sword": true
 			},
@@ -1126,7 +1126,7 @@
 		},
 		{
 			"name": "Nine Lives Stealer",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"sword": true
 			},
@@ -1161,7 +1161,7 @@
 		},
 		{
 			"name": "Sword of Life Stealing",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"sword": true
 			},
@@ -1179,7 +1179,7 @@
 		},
 		{
 			"name": "Sword of Sharpness",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"sword": true,
 				"dmgType": "S"
@@ -1200,7 +1200,7 @@
 		},
 		{
 			"name": "Sword of Vengeance",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"sword": true
 			},
@@ -1237,7 +1237,7 @@
 		},
 		{
 			"name": "Sword of Wounding",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"sword": true
 			},
@@ -1256,7 +1256,7 @@
 		},
 		{
 			"name": "Vicious Weapon",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"weapon": true
 			},
@@ -1277,7 +1277,7 @@
 		},
 		{
 			"name": "Vorpal Sword",
-			"type": "GV",
+			"type": "MV",
 			"requires": {
 				"sword": true,
 				"dmgType": "S"

--- a/js/items.js
+++ b/js/items.js
@@ -1,7 +1,8 @@
 const ITEMS_JSON_URL = "data/items.json";
 const BASIC_ITEMS_JSON_URL = "data/basicitems.json";
 const MAGIC_VARIANTS_JSON_URL = "data/magicvariants.json";
-const TYPE_DOSH ="$";
+const TYPE_DOSH = "$";
+const CATEGORY_SPECIFIC_VARIANT = "Specific Variant";
 let tabledefault = "";
 let itemList;
 let basicItemList;
@@ -42,6 +43,7 @@ function mergeBasicItems(variantData) {
 	itemList = itemList.concat(variantList);
 	for (let i = 0; i < basicItemList.length; i++) {
 		const curBasicItem = basicItemList[i];
+		basicItemList[i].category = "Basic";
 		if(curBasicItem.entries === undefined) curBasicItem.entries=[];
 		for (let j = 0; j < variantList.length; j++) {
 			const curVariant = variantList[j];
@@ -56,6 +58,7 @@ function mergeBasicItems(variantData) {
 				const curInherits = curVariant.inherits
 				const tmpBasicItem = JSON.parse(JSON.stringify(curBasicItem));
 				delete tmpBasicItem.value; // Magic items do not inherit the value of the non-magical item
+				tmpBasicItem.category = "Specific Variant";
 				for (const inheritedProperty in curInherits) {
 					if (curInherits.hasOwnProperty(inheritedProperty)) {
 						if (inheritedProperty === "namePrefix") {
@@ -89,6 +92,8 @@ function pushObject(targetObject, objectToBePushed) {
 
 function enhanceItems() {
 	for (let i = 0; i < itemList.length; i++) {
+		if (itemList[i].type === "GV") itemList[i].category = "Generic Variant";
+		if (itemList[i].category === undefined) itemList[i].category = "Other";
 		const item = itemList[i];
 		if (item.entries === undefined) itemList[i].entries=[];
 		if (item.type && typeList[item.type]) for (let j = 0; j < typeList[item.type].entries.length; j++) itemList[i].entries = pushObject(itemList[i].entries,typeList[item.type].entries[j]);
@@ -129,7 +134,7 @@ function rarityValue(rarity) { //Ordered by most frequently occuring rarities in
 	return 0;
 }
 
-function sortitems(a, b, o) {
+function sortItems(a, b, o) {
 	if (o.valueName === "name") {
 		return b._values.name.toLowerCase() > a._values.name.toLowerCase() ? 1 : -1;
 	} else if (o.valueName === "type") {
@@ -148,37 +153,21 @@ function populateTablesAndFilters() {
 	tabledefault = $("#stats").html();
 
 	const filterAndSearchBar = document.getElementById(ID_SEARCH_BAR);
-	const filterList = [];
 	const sourceFilter = new Filter("Source", FLTR_SOURCE, [], Parser.sourceJsonToFull, Parser.stringToSlug);
-	filterList.push(sourceFilter);
 	const typeFilter = new Filter("Type", FLTR_TYPE, [], Filter.asIs, Filter.asIs);
-	filterList.push(typeFilter);
-	const tierFilter = new Filter("Tier", FLTR_TIER, [
-		"None",
-		"Minor",
-		"Major",
-	], Filter.asIs, Filter.asIs);
-	filterList.push(tierFilter);
-	const rarityFilter = new Filter("Rarity", FLTR_RARITY, [
-		"None",
-		"Common",
-		"Uncommon",
-		"Rare",
-		"Very Rare",
-		"Legendary",
-		"Artifact",
-		"Unknown",
-	], Filter.asIs, Filter.asIs);
-	filterList.push(rarityFilter);
+	const tierFilter = new Filter("Tier", FLTR_TIER, ["None", "Minor", "Major"], Filter.asIs, Filter.asIs);
+	const rarityFilter = new Filter("Rarity", FLTR_RARITY, ["None", "Common", "Uncommon", "Rare", "Very Rare", "Legendary", "Artifact", "Unknown"], Filter.asIs, Filter.asIs);
 	const attunementFilter = new Filter("Attunement", FLTR_ATTUNEMENT, ["Yes", "By...", "Optional", "No"], Filter.asIs, Parser.stringToSlug);
-	filterList.push(attunementFilter);
+	const categoryFilter = new Filter("Category", FLTR_CATEGORY, ["Basic", "Generic Variant", "Specific Variant", "Other"], Filter.asIs, Parser.stringToSlug);
+	const filterList = [sourceFilter, typeFilter, tierFilter, rarityFilter, attunementFilter, categoryFilter];
 	const filterBox = new FilterBox(filterAndSearchBar, filterList);
-	const liList = {mundane:"", magic:""}; // store the <li> tag content here and change the DOM once for each after the loop
+	const liList = {mundane:"", magic:""}; // store the <li> tag content here and change the DOM once for each property after the loop
 
 	for (let i = 0; i < itemList.length; i++) {
 		const curitem = itemList[i];
 		const name = curitem.name;
 		const rarity = curitem.rarity;
+		const category = curitem.category;
 		const source = curitem.source;
 		const sourceAbv = Parser.sourceJsonToAbv(source);
 		const sourceFull = Parser.sourceJsonToFull(source);
@@ -209,7 +198,15 @@ function populateTablesAndFilters() {
 				itemList[i].reqAttune = "(Requires Attunement "+curitem.reqAttune+")";
 			}
 		}
-		liList[rarity === "None" || rarity === "Unknown" ? "mundane" : "magic"] += `<li ${FLTR_SOURCE}='${source}' ${FLTR_TYPE}='${typeList}' ${FLTR_TIER}='${tierTagsString}' ${FLTR_RARITY}='${rarity}' ${FLTR_ATTUNEMENT}='${attunement}'><a id='${i}' href="#${encodeForHash(name)}_${encodeForHash(source)}" title="${name}"><span class='name col-xs-4'>${name}</span> <span class='type col-xs-4 col-xs-4-3'>${type.join(", ")}</span> <span class='source col-xs-1 col-xs-1-7 source${sourceAbv}' title="${sourceFull}">${sourceAbv}</span> <span class='rarity col-xs-2'>${rarity}</span></a></li>`;
+		liList[rarity === "None" || rarity === "Unknown" ? "mundane" : "magic"] += `
+			<li ${FLTR_SOURCE}='${source}' ${FLTR_TYPE}='${typeList}' ${FLTR_TIER}='${tierTagsString}' ${FLTR_RARITY}='${rarity}' ${FLTR_ATTUNEMENT}='${attunement}' ${FLTR_CATEGORY}='${category}'>
+				<a id='${i}' href="#${encodeForHash(name)}_${encodeForHash(source)}" title="${name}">
+					<span class='name col-xs-4'>${name}</span>
+					<span class='type col-xs-4 col-xs-4-3'>${type.join(", ")}</span>
+					<span class='source col-xs-1 col-xs-1-7 source${sourceAbv}' title="${sourceFull}">${sourceAbv}</span>
+					<span class='rarity col-xs-2'>${rarity}</span>
+				</a>
+			</li>`;
 
 		// populate filters
 		if ($.inArray(source, sourceFilter.items) === -1) sourceFilter.items.push(source);
@@ -236,6 +233,7 @@ function populateTablesAndFilters() {
 	document.getElementById(ID_RESET_BUTTON).addEventListener(EVNT_CLICK, function() {
 		filterBox.reset();
 		deselectDosh(true);
+		deselectSpecificVariants(true);
 	}, false);
 
 	filterBox.render();
@@ -266,19 +264,19 @@ function populateTablesAndFilters() {
 		const rightTier = f[tierFilter.header][FilterBox.VAL_SELECT_ALL] || f[tierFilter.header][tierFilter.valueFunction($(item.elm).attr(tierFilter.storageAttribute))];
 		const rightRarity = f[rarityFilter.header][FilterBox.VAL_SELECT_ALL] || f[rarityFilter.header][rarityFilter.valueFunction($(item.elm).attr(rarityFilter.storageAttribute))];
 		const rightAttunement = f[attunementFilter.header][FilterBox.VAL_SELECT_ALL] || f[attunementFilter.header][attunementFilter.valueFunction($(item.elm).attr(attunementFilter.storageAttribute))];
-		return rightSource && rightType && rightTier && rightRarity && rightAttunement;
+		const rightCategory = f[categoryFilter.header][FilterBox.VAL_SELECT_ALL] || f[categoryFilter.header][categoryFilter.valueFunction($(item.elm).attr(categoryFilter.storageAttribute))];
+		return rightSource && rightType && rightTier && rightRarity && rightAttunement && rightCategory;
 	}
 
 	$("#filtertools button.sort").on("click", function() {
-		if ($(this).attr("sortby") === "asc") {
-			$(this).attr("sortby", "desc");
-		} else $(this).attr("sortby", "asc");
-		magiclist.sort($(this).attr("sort"), { order: $(this).attr("sortby"), sortFunction: sortitems });
-		mundanelist.sort($(this).attr("sort"), { order: $(this).attr("sortby"), sortFunction: sortitems });
+		$(this).attr("sortby", $(this).attr("sortby") === "asc" ? "desc" : "asc");
+		magiclist.sort($(this).attr("sort"), { order: $(this).attr("sortby"), sortFunction: sortItems });
+		mundanelist.sort($(this).attr("sort"), { order: $(this).attr("sortby"), sortFunction: sortItems });
 	});
 
-	// default de-select Dosh types
+	// De-select Dosh types and Specific Variants by default
 	deselectDosh(true);
+	deselectSpecificVariants(true);
 
 	function deselectDosh(hardDeselect) {
 		hardDeselect = hardDeselect === undefined || hardDeselect === null ? false : hardDeselect;
@@ -298,6 +296,27 @@ function populateTablesAndFilters() {
 			filterBox.deselectIf(function(val) {
 				return val === TYPE_DOSH
 			}, typeFilter.header);
+		}
+	}
+
+	function deselectSpecificVariants(hardDeselect) {
+		hardDeselect = hardDeselect === undefined || hardDeselect === null ? false : hardDeselect;
+		if (window.location.hash.length) {
+			const itemCategory = itemList[getSelectedListElement().attr("id")].category;
+			if (itemCategory === CATEGORY_SPECIFIC_VARIANT && hardDeselect) {
+				deselNoHash();
+			} else {
+				filterBox.deselectIf(function (val) {
+					return val === CATEGORY_SPECIFIC_VARIANT && itemCategory !== val
+				}, categoryFilter.header);
+			}
+		} else {
+			deselNoHash();
+		}
+		function deselNoHash() {
+			filterBox.deselectIf(function(val) {
+				return val === CATEGORY_SPECIFIC_VARIANT
+			}, categoryFilter.header);
 		}
 	}
 

--- a/js/items.js
+++ b/js/items.js
@@ -198,7 +198,9 @@ function populateTablesAndFilters() {
 				itemList[i].reqAttune = "(Requires Attunement "+curitem.reqAttune+")";
 			}
 		}
-		liList[rarity === "None" || rarity === "Unknown" ? "mundane" : "magic"] += `<li ${FLTR_SOURCE}='${source}' ${FLTR_TYPE}='${typeList}' ${FLTR_TIER}='${tierTagsString}' ${FLTR_RARITY}='${rarity}' ${FLTR_ATTUNEMENT}='${attunement}'><a id='${i}' href="#${encodeForHash(name)}_${encodeForHash(source)}" title="${name}"><span class='name col-xs-4'>${name}</span> <span class='type col-xs-4 col-xs-4-3'>${type.join(", ")}</span> <span class='source col-xs-1 col-xs-1-7 source${sourceAbv}' title="${sourceFull}">${sourceAbv}</span> <span class='rarity col-xs-2'>${rarity}</span></a></li>`;
+		liList[rarity === "None" || rarity === "Unknown" ? "mundane" : "magic"] += `
+			<li ${FLTR_SOURCE}='${source}' ${FLTR_TYPE}='${typeList}' ${FLTR_TIER}='${tierTagsString}' ${FLTR_RARITY}='${rarity}' ${FLTR_ATTUNEMENT}='${attunement}' ${FLTR_CATEGORY}='${category}'>
+				<a id='${i}' href="#${encodeForHash(name)}_${encodeForHash(source)}" title="${name}">
 					<span class='name col-xs-4'>${name}</span>
 					<span class='type col-xs-4 col-xs-4-3'>${type.join(", ")}</span>
 					<span class='source col-xs-1 col-xs-1-7 source${sourceAbv}' title="${sourceFull}">${sourceAbv}</span>

--- a/js/items.js
+++ b/js/items.js
@@ -1,7 +1,8 @@
 const ITEMS_JSON_URL = "data/items.json";
 const BASIC_ITEMS_JSON_URL = "data/basicitems.json";
 const MAGIC_VARIANTS_JSON_URL = "data/magicvariants.json";
-const TYPE_DOSH ="$";
+const TYPE_DOSH = "$";
+const CATEGORY_SPECIFIC_VARIANT = "Specific Variant";
 let tabledefault = "";
 let itemList;
 let basicItemList;
@@ -42,6 +43,7 @@ function mergeBasicItems(variantData) {
 	itemList = itemList.concat(variantList);
 	for (let i = 0; i < basicItemList.length; i++) {
 		const curBasicItem = basicItemList[i];
+		basicItemList[i].category = "Basic";
 		if(curBasicItem.entries === undefined) curBasicItem.entries=[];
 		for (let j = 0; j < variantList.length; j++) {
 			const curVariant = variantList[j];
@@ -56,6 +58,7 @@ function mergeBasicItems(variantData) {
 				const curInherits = curVariant.inherits
 				const tmpBasicItem = JSON.parse(JSON.stringify(curBasicItem));
 				delete tmpBasicItem.value; // Magic items do not inherit the value of the non-magical item
+				tmpBasicItem.category = "Specific Variant";
 				for (const inheritedProperty in curInherits) {
 					if (curInherits.hasOwnProperty(inheritedProperty)) {
 						if (inheritedProperty === "namePrefix") {
@@ -89,6 +92,8 @@ function pushObject(targetObject, objectToBePushed) {
 
 function enhanceItems() {
 	for (let i = 0; i < itemList.length; i++) {
+		if (itemList[i].type === "GV") itemList[i].category = "Generic Variant";
+		if (itemList[i].category === undefined) itemList[i].category = "Other";
 		const item = itemList[i];
 		if (item.entries === undefined) itemList[i].entries=[];
 		if (item.type && typeList[item.type]) for (let j = 0; j < typeList[item.type].entries.length; j++) itemList[i].entries = pushObject(itemList[i].entries,typeList[item.type].entries[j]);
@@ -129,7 +134,7 @@ function rarityValue(rarity) { //Ordered by most frequently occuring rarities in
 	return 0;
 }
 
-function sortitems(a, b, o) {
+function sortItems(a, b, o) {
 	if (o.valueName === "name") {
 		return b._values.name.toLowerCase() > a._values.name.toLowerCase() ? 1 : -1;
 	} else if (o.valueName === "type") {
@@ -148,37 +153,21 @@ function populateTablesAndFilters() {
 	tabledefault = $("#stats").html();
 
 	const filterAndSearchBar = document.getElementById(ID_SEARCH_BAR);
-	const filterList = [];
 	const sourceFilter = new Filter("Source", FLTR_SOURCE, [], Parser.sourceJsonToFull, Parser.stringToSlug);
-	filterList.push(sourceFilter);
 	const typeFilter = new Filter("Type", FLTR_TYPE, [], Filter.asIs, Filter.asIs);
-	filterList.push(typeFilter);
-	const tierFilter = new Filter("Tier", FLTR_TIER, [
-		"None",
-		"Minor",
-		"Major",
-	], Filter.asIs, Filter.asIs);
-	filterList.push(tierFilter);
-	const rarityFilter = new Filter("Rarity", FLTR_RARITY, [
-		"None",
-		"Common",
-		"Uncommon",
-		"Rare",
-		"Very Rare",
-		"Legendary",
-		"Artifact",
-		"Unknown",
-	], Filter.asIs, Filter.asIs);
-	filterList.push(rarityFilter);
+	const tierFilter = new Filter("Tier", FLTR_TIER, ["None", "Minor", "Major"], Filter.asIs, Filter.asIs);
+	const rarityFilter = new Filter("Rarity", FLTR_RARITY, ["None", "Common", "Uncommon", "Rare", "Very Rare", "Legendary", "Artifact", "Unknown"], Filter.asIs, Filter.asIs);
 	const attunementFilter = new Filter("Attunement", FLTR_ATTUNEMENT, ["Yes", "By...", "Optional", "No"], Filter.asIs, Parser.stringToSlug);
-	filterList.push(attunementFilter);
+	const categoryFilter = new Filter("Category", FLTR_CATEGORY, ["Basic", "Generic Variant", "Specific Variant", "Other"], Filter.asIs, Parser.stringToSlug);
+	const filterList = [sourceFilter, typeFilter, tierFilter, rarityFilter, attunementFilter, categoryFilter];
 	const filterBox = new FilterBox(filterAndSearchBar, filterList);
-	const liList = {mundane:"", magic:""}; // store the <li> tag content here and change the DOM once for each after the loop
+	const liList = {mundane:"", magic:""}; // store the <li> tag content here and change the DOM once for each property after the loop
 
 	for (let i = 0; i < itemList.length; i++) {
 		const curitem = itemList[i];
 		const name = curitem.name;
 		const rarity = curitem.rarity;
+		const category = curitem.category;
 		const source = curitem.source;
 		const sourceAbv = Parser.sourceJsonToAbv(source);
 		const sourceFull = Parser.sourceJsonToFull(source);
@@ -210,6 +199,12 @@ function populateTablesAndFilters() {
 			}
 		}
 		liList[rarity === "None" || rarity === "Unknown" ? "mundane" : "magic"] += `<li ${FLTR_SOURCE}='${source}' ${FLTR_TYPE}='${typeList}' ${FLTR_TIER}='${tierTagsString}' ${FLTR_RARITY}='${rarity}' ${FLTR_ATTUNEMENT}='${attunement}'><a id='${i}' href="#${encodeForHash(name)}_${encodeForHash(source)}" title="${name}"><span class='name col-xs-4'>${name}</span> <span class='type col-xs-4 col-xs-4-3'>${type.join(", ")}</span> <span class='source col-xs-1 col-xs-1-7 source${sourceAbv}' title="${sourceFull}">${sourceAbv}</span> <span class='rarity col-xs-2'>${rarity}</span></a></li>`;
+					<span class='name col-xs-4'>${name}</span>
+					<span class='type col-xs-4 col-xs-4-3'>${type.join(", ")}</span>
+					<span class='source col-xs-1 col-xs-1-7 source${sourceAbv}' title="${sourceFull}">${sourceAbv}</span>
+					<span class='rarity col-xs-2'>${rarity}</span>
+				</a>
+			</li>`;
 
 		// populate filters
 		if ($.inArray(source, sourceFilter.items) === -1) sourceFilter.items.push(source);
@@ -236,6 +231,7 @@ function populateTablesAndFilters() {
 	document.getElementById(ID_RESET_BUTTON).addEventListener(EVNT_CLICK, function() {
 		filterBox.reset();
 		deselectDosh(true);
+		deselectSpecificVariants(true);
 	}, false);
 
 	filterBox.render();
@@ -266,19 +262,19 @@ function populateTablesAndFilters() {
 		const rightTier = f[tierFilter.header][FilterBox.VAL_SELECT_ALL] || f[tierFilter.header][tierFilter.valueFunction($(item.elm).attr(tierFilter.storageAttribute))];
 		const rightRarity = f[rarityFilter.header][FilterBox.VAL_SELECT_ALL] || f[rarityFilter.header][rarityFilter.valueFunction($(item.elm).attr(rarityFilter.storageAttribute))];
 		const rightAttunement = f[attunementFilter.header][FilterBox.VAL_SELECT_ALL] || f[attunementFilter.header][attunementFilter.valueFunction($(item.elm).attr(attunementFilter.storageAttribute))];
-		return rightSource && rightType && rightTier && rightRarity && rightAttunement;
+		const rightCategory = f[categoryFilter.header][FilterBox.VAL_SELECT_ALL] || f[categoryFilter.header][categoryFilter.valueFunction($(item.elm).attr(categoryFilter.storageAttribute))];
+		return rightSource && rightType && rightTier && rightRarity && rightAttunement && rightCategory;
 	}
 
 	$("#filtertools button.sort").on("click", function() {
-		if ($(this).attr("sortby") === "asc") {
-			$(this).attr("sortby", "desc");
-		} else $(this).attr("sortby", "asc");
-		magiclist.sort($(this).attr("sort"), { order: $(this).attr("sortby"), sortFunction: sortitems });
-		mundanelist.sort($(this).attr("sort"), { order: $(this).attr("sortby"), sortFunction: sortitems });
+		$(this).attr("sortby", $(this).attr("sortby") === "asc" ? "desc" : "asc");
+		magiclist.sort($(this).attr("sort"), { order: $(this).attr("sortby"), sortFunction: sortItems });
+		mundanelist.sort($(this).attr("sort"), { order: $(this).attr("sortby"), sortFunction: sortItems });
 	});
 
-	// default de-select Dosh types
+	// De-select Dosh types and Specific Variants by default
 	deselectDosh(true);
+	deselectSpecificVariants(true);
 
 	function deselectDosh(hardDeselect) {
 		hardDeselect = hardDeselect === undefined || hardDeselect === null ? false : hardDeselect;
@@ -298,6 +294,27 @@ function populateTablesAndFilters() {
 			filterBox.deselectIf(function(val) {
 				return val === TYPE_DOSH
 			}, typeFilter.header);
+		}
+	}
+
+	function deselectSpecificVariants(hardDeselect) {
+		hardDeselect = hardDeselect === undefined || hardDeselect === null ? false : hardDeselect;
+		if (window.location.hash.length) {
+			const itemCategory = itemList[getSelectedListElement().attr("id")].category;
+			if (itemCategory === CATEGORY_SPECIFIC_VARIANT && hardDeselect) {
+				deselNoHash();
+			} else {
+				filterBox.deselectIf(function (val) {
+					return val === CATEGORY_SPECIFIC_VARIANT && itemCategory !== val
+				}, categoryFilter.header);
+			}
+		} else {
+			deselNoHash();
+		}
+		function deselNoHash() {
+			filterBox.deselectIf(function(val) {
+				return val === CATEGORY_SPECIFIC_VARIANT
+			}, categoryFilter.header);
 		}
 	}
 

--- a/js/items.js
+++ b/js/items.js
@@ -198,9 +198,7 @@ function populateTablesAndFilters() {
 				itemList[i].reqAttune = "(Requires Attunement "+curitem.reqAttune+")";
 			}
 		}
-		liList[rarity === "None" || rarity === "Unknown" ? "mundane" : "magic"] += `
-			<li ${FLTR_SOURCE}='${source}' ${FLTR_TYPE}='${typeList}' ${FLTR_TIER}='${tierTagsString}' ${FLTR_RARITY}='${rarity}' ${FLTR_ATTUNEMENT}='${attunement}' ${FLTR_CATEGORY}='${category}'>
-				<a id='${i}' href="#${encodeForHash(name)}_${encodeForHash(source)}" title="${name}">
+		liList[rarity === "None" || rarity === "Unknown" ? "mundane" : "magic"] += `<li ${FLTR_SOURCE}='${source}' ${FLTR_TYPE}='${typeList}' ${FLTR_TIER}='${tierTagsString}' ${FLTR_RARITY}='${rarity}' ${FLTR_ATTUNEMENT}='${attunement}'><a id='${i}' href="#${encodeForHash(name)}_${encodeForHash(source)}" title="${name}"><span class='name col-xs-4'>${name}</span> <span class='type col-xs-4 col-xs-4-3'>${type.join(", ")}</span> <span class='source col-xs-1 col-xs-1-7 source${sourceAbv}' title="${sourceFull}">${sourceAbv}</span> <span class='rarity col-xs-2'>${rarity}</span></a></li>`;
 					<span class='name col-xs-4'>${name}</span>
 					<span class='type col-xs-4 col-xs-4-3'>${type.join(", ")}</span>
 					<span class='source col-xs-1 col-xs-1-7 source${sourceAbv}' title="${sourceFull}">${sourceAbv}</span>

--- a/js/utils.js
+++ b/js/utils.js
@@ -60,7 +60,6 @@ FLTR_ACTION = "filterAction";
 FLTR_TIER = "filterTier";
 FLTR_RARITY = "filterRarity";
 FLTR_ATTUNEMENT = "filterAttunement";
-FLTR_CATEGORY = "filterCategory";
 FLTR_LIST_SEP = ";";
 
 CLSS_NON_STANDARD_SOURCE = "spicy-sauce";
@@ -1029,7 +1028,7 @@ Parser.ITEM_TYPE_JSON_TO_ABV = {
 	"M": "Melee Weapon",
 	"MA": "Medium Armor",
 	"MNT": "Mount",
-	"GV": "Generic Variant",
+	"MV": "Magical Variant",
 	"P": "Potion",
 	"R": "Ranged Weapon",
 	"RD": "Rod",

--- a/js/utils.js
+++ b/js/utils.js
@@ -60,6 +60,7 @@ FLTR_ACTION = "filterAction";
 FLTR_TIER = "filterTier";
 FLTR_RARITY = "filterRarity";
 FLTR_ATTUNEMENT = "filterAttunement";
+FLTR_CATEGORY = "filterCategory";
 FLTR_LIST_SEP = ";";
 
 CLSS_NON_STANDARD_SOURCE = "spicy-sauce";
@@ -1028,7 +1029,7 @@ Parser.ITEM_TYPE_JSON_TO_ABV = {
 	"M": "Melee Weapon",
 	"MA": "Medium Armor",
 	"MNT": "Mount",
-	"MV": "Magical Variant",
+	"GV": "Generic Variant",
 	"P": "Potion",
 	"R": "Ranged Weapon",
 	"RD": "Rod",


### PR DESCRIPTION
**data/items.json**
Finished adding hyperlinks for the remaining referenced spells.

**data/magicvariants.json**
Changed `"type": "MV"` to `"type": "GV"`.

**js/items.js**
Added a `"category"` property: Basic|Generic Variant|Specific Variant|Other.
Added a Category filter - tried to default it to deselect Specific Variant; it's work-in-progress.

**js/utils.js**
Added FLTR_CATEGORY constant.
Updated Parser.ITEM_TYPE_JSON_TO_ABV object.