### PR TITLE
Auto-deselect tweak

### DIFF
--- a/js/items.js
+++ b/js/items.js
@@ -307,7 +307,7 @@ function populateTablesAndFilters() {
 				deselNoHash();
 			} else {
 				filterBox.deselectIf(function (val) {
-					return val === CATEGORY_SPECIFIC_VARIANT && itemCategory !== val
+					return val === categoryFilter.valueFunction(CATEGORY_SPECIFIC_VARIANT) && categoryFilter.valueFunction(itemCategory) !== val
 				}, categoryFilter.header);
 			}
 		} else {
@@ -315,7 +315,7 @@ function populateTablesAndFilters() {
 		}
 		function deselNoHash() {
 			filterBox.deselectIf(function(val) {
-				return val === CATEGORY_SPECIFIC_VARIANT
+				return val === categoryFilter.valueFunction(CATEGORY_SPECIFIC_VARIANT)
 			}, categoryFilter.header);
 		}
 	}


### PR DESCRIPTION
You have to pass the exact value the filter knows about, which is the `item` with the filter's `valueFunction` applied. I realise this is not particularly intuitive, will probably fix this in the upcoming filter overhaul.